### PR TITLE
Generic resource retrieval

### DIFF
--- a/pkg/handlers/workspace/handler.go
+++ b/pkg/handlers/workspace/handler.go
@@ -1,7 +1,9 @@
 package workspace
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -17,126 +19,185 @@ import (
 
 const (
 	defaultInterval = 7 // 7 days ~ 1 week
+	dateLayout      = "02.01.2006"
 )
 
-type Handler struct {
+type Router struct {
 	explorer account.Explorer
 }
 
-func NewHandler(explorer account.Explorer) *Handler {
-	return &Handler{
+func NewWorkspaceRouter(explorer account.Explorer) *Router {
+	return &Router{
 		explorer: explorer,
 	}
 }
 
-func (h *Handler) ListWorkspaces(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	logger := zerolog.Ctx(ctx)
+func (r *Router) Routes() chi.Router {
+	router := chi.NewRouter()
+	router.Get("/workspaces", r.ListWorkspaces)
+	router.Get("/workspaces/{workspace}/resources", r.ListResources)
+	router.Get("/workspaces/{workspace}/{resource}/cost", r.GetResourceCost)
+	router.Get("/workspaces/{workspace}/metrics/cost", r.GetWorkspaceMetricsCost)
+	return router
+}
 
-	workspaces, err := h.explorer.ListWorkspaces(ctx)
+func (r *Router) ListWorkspaces(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	workspaces, err := r.explorer.ListWorkspaces(ctx)
+	if err != nil {
+		handleError(ctx, w, http.StatusInternalServerError, err)
+		return
+	}
+
 	var response []api.Workspace
 	for _, ws := range workspaces {
 		response = append(response, api.Workspace{Name: ws.Name})
 	}
 
-	err = json.NewEncoder(w).Encode(workspaces)
-
+	err = jsonResponse(w, response)
 	if err != nil {
-		logger.Error().
-			Err(err).
-			Msg("failed to encode workspaces")
+		handleError(ctx, w, http.StatusInternalServerError, err)
 	}
 }
 
-func (h *Handler) ListResources(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	logger := zerolog.Ctx(ctx)
+func (r *Router) ListResources(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
 
-	ws := chi.URLParam(r, "workspace")
-
-	wsExplorer, err := h.explorer.GetWorkspaceExplorer(ctx, domain.Workspace{Name: ws})
+	ws := getWorkspaceFromPath(req)
+	wsExplorer, err := r.explorer.GetWorkspaceExplorer(ctx, ws)
 	if err != nil {
-		logger.Error().
-			Err(err).
-			Str("ws", ws).
-			Msg("failed to get workspace explorer")
-		http.Error(w, "workspace not found", http.StatusNotFound)
+		handleError(ctx, w, http.StatusInternalServerError, err)
 		return
 	}
 
 	resources, err := wsExplorer.ListSupportedResources(ctx)
+	if err != nil {
+		handleError(ctx, w, http.StatusInternalServerError, err)
+		return
+	}
+
 	var response []api.WorkspaceResource
 	for _, r := range resources {
 		response = append(response, api.WorkspaceResource{Name: r.ResourceName})
 	}
 
-	err = json.NewEncoder(w).Encode(response)
+	err = jsonResponse(w, response)
 	if err != nil {
-		logger.Error().
-			Err(err).
-			Str("ws", ws).
-			Msg("failed to encode workspace resources")
+		handleError(ctx, w, http.StatusInternalServerError, err)
 	}
 }
 
-func (h *Handler) GetResourceCost(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	logger := zerolog.Ctx(ctx)
-	ws := chi.URLParam(r, "workspace")
-	resource := chi.URLParam(r, "resource")
+func (r *Router) GetResourceCost(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	ws := getWorkspaceFromPath(req)
+	resource := chi.URLParam(req, "resource")
 
-	from := r.URL.Query().Get("from")
-	to := r.URL.Query().Get("to")
-
-	const dateLayout = "2006-01-02"
-
-	var endTime time.Time
-	if to == "" {
-		endTime = time.Now()
-	} else {
-		var err error
-		endTime, err = time.Parse(dateLayout, to)
-		if err != nil {
-			http.Error(w, "invalid 'to' date format. Expected format: YYYY-MM-DD", http.StatusBadRequest)
-			return
-		}
-	}
-
-	var startTime time.Time
-	if from == "" {
-		startTime = endTime.AddDate(0, 0, defaultInterval*-1)
-	} else {
-		var err error
-		startTime, err = time.Parse(dateLayout, from)
-		if err != nil {
-			http.Error(w, "invalid 'from' date format. Expected format: YYYY-MM-DD", http.StatusBadRequest)
-			return
-		}
-	}
-
-	costManager, err := h.explorer.GetWorkspaceCostManager(ctx, domain.Workspace{Name: ws})
+	endTime, err := parseDateParam(req, "to", time.Now())
 	if err != nil {
-		logger.Error().
-			Err(err).
-			Str("ws", ws).
-			Msg("failed to get workspace cost manager")
-		http.Error(w, "workspace not found", http.StatusNotFound)
+		handleError(ctx, w, http.StatusBadRequest, err)
 		return
 	}
 
-	wsResource := domain.WorkspaceResource{WorkspaceName: ws, ResourceName: resource}
-	records, err := costManager.GetResourceCost(ctx, wsResource, startTime, endTime)
+	startTime, err := parseDateParam(req, "from", time.Now().AddDate(0, 0, -defaultInterval))
+	if err != nil {
+		handleError(ctx, w, http.StatusBadRequest, err)
+		return
+	}
+
+	costManager, err := r.explorer.GetWorkspaceCostManager(ctx, ws)
+	if err != nil {
+		handleError(ctx, w, http.StatusNotFound, err)
+		return
+	}
+
+	resources := domain.WorkspaceResources{WorkspaceName: ws.Name, Resources: []string{resource}}
+	records, err := costManager.GetResourcesCost(ctx, resources, startTime, endTime)
+	if err != nil {
+		handleError(ctx, w, http.StatusInternalServerError, err)
+		return
+	}
 
 	apiRecords := make([]api.ResourceCost, 0, len(records))
 	for _, r := range records {
 		apiRecords = append(apiRecords, adapters.MapResourceCostDomainToApi(r))
 	}
 
-	err = json.NewEncoder(w).Encode(apiRecords)
+	err = jsonResponse(w, apiRecords)
 	if err != nil {
-		logger.Error().
-			Err(err).
-			Str("ws", ws).
-			Msg("failed to encode resource cost")
+		handleError(ctx, w, http.StatusInternalServerError, err)
 	}
+}
+
+func (r *Router) GetWorkspaceMetricsCost(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	ws := getWorkspaceFromPath(req)
+	resourceTypes := req.URL.Query()["resource_type"]
+
+	endTime, err := parseDateParam(req, "to", time.Now())
+	if err != nil {
+		handleError(ctx, w, http.StatusBadRequest, err)
+		return
+	}
+
+	startTime, err := parseDateParam(req, "from", time.Now().AddDate(0, 0, -defaultInterval))
+	if err != nil {
+		handleError(ctx, w, http.StatusBadRequest, err)
+		return
+	}
+
+	costManager, err := r.explorer.GetWorkspaceCostManager(ctx, ws)
+	if err != nil {
+		handleError(ctx, w, http.StatusNotFound, err)
+		return
+	}
+
+	resources := domain.WorkspaceResources{WorkspaceName: ws.Name, Resources: resourceTypes}
+	records, err := costManager.GetResourcesCost(ctx, resources, startTime, endTime)
+	if err != nil {
+		handleError(ctx, w, http.StatusInternalServerError, err)
+		return
+	}
+
+	apiRecords := make([]api.ResourceCost, 0, len(records))
+	for _, r := range records {
+		apiRecords = append(apiRecords, adapters.MapResourceCostDomainToApi(r))
+	}
+
+	err = jsonResponse(w, apiRecords)
+	if err != nil {
+		handleError(ctx, w, http.StatusInternalServerError, err)
+	}
+}
+
+func handleError(ctx context.Context, w http.ResponseWriter, statusCode int, err error) {
+	if err == nil {
+		return
+	}
+
+	l := zerolog.Ctx(ctx)
+	l.Error().Err(err).Msg("handler error")
+	http.Error(w, err.Error(), statusCode)
+}
+
+func jsonResponse(w http.ResponseWriter, data interface{}) error {
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(data)
+}
+
+func parseDateParam(r *http.Request, paramName string, defaultDate time.Time) (time.Time, error) {
+	param := r.URL.Query().Get(paramName)
+
+	if param == "" {
+		return defaultDate, nil
+	}
+
+	parsed, err := time.Parse(dateLayout, param)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid '%s' date format. Expected format: DD.MM.YYYY", paramName)
+	}
+	return parsed, nil
+}
+
+func getWorkspaceFromPath(r *http.Request) domain.Workspace {
+	return domain.Workspace{Name: chi.URLParam(r, "workspace")}
 }

--- a/pkg/handlers/workspace/handler.go
+++ b/pkg/handlers/workspace/handler.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	defaultInterval = 7 // 7 days ~ 1 week
-	dateLayout      = "02.01.2006"
+	dateLayout      = "02-01-2006"
 )
 
 type Router struct {
@@ -49,7 +49,7 @@ func (r *Router) ListWorkspaces(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var response []api.Workspace
+	response := make([]api.Workspace, 0, len(workspaces))
 	for _, ws := range workspaces {
 		response = append(response, api.Workspace{Name: ws.Name})
 	}
@@ -76,7 +76,7 @@ func (r *Router) ListResources(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var response []api.WorkspaceResource
+	response := make([]api.WorkspaceResource, 0, len(resources))
 	for _, r := range resources {
 		response = append(response, api.WorkspaceResource{Name: r.ResourceName})
 	}
@@ -193,7 +193,7 @@ func parseDateParam(r *http.Request, paramName string, defaultDate time.Time) (t
 
 	parsed, err := time.Parse(dateLayout, param)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("invalid '%s' date format. Expected format: DD.MM.YYYY", paramName)
+		return time.Time{}, fmt.Errorf("invalid '%s' date format. Expected format: DD-MM-YYYY", paramName)
 	}
 	return parsed, nil
 }

--- a/pkg/handlers/workspace/handler_test.go
+++ b/pkg/handlers/workspace/handler_test.go
@@ -1,0 +1,425 @@
+package workspace
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/de-tools/data-atlas/pkg/services/account/workspace"
+
+	"github.com/de-tools/data-atlas/pkg/models/api"
+	"github.com/de-tools/data-atlas/pkg/models/domain"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockAccountExplorer struct {
+	mock.Mock
+}
+
+func (m *mockAccountExplorer) ListWorkspaces(ctx context.Context) ([]domain.Workspace, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]domain.Workspace), args.Error(1)
+}
+
+func (m *mockAccountExplorer) GetWorkspaceExplorer(
+	ctx context.Context,
+	ws domain.Workspace,
+) (workspace.Explorer, error) {
+	args := m.Called(ctx, ws)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(workspace.Explorer), args.Error(1)
+}
+
+func (m *mockAccountExplorer) GetWorkspaceCostManager(
+	ctx context.Context,
+	ws domain.Workspace,
+) (workspace.CostManager, error) {
+	args := m.Called(ctx, ws)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(workspace.CostManager), args.Error(1)
+}
+
+type mockWorkspaceExplorer struct {
+	mock.Mock
+}
+
+func (m *mockWorkspaceExplorer) ListSupportedResources(ctx context.Context) ([]domain.WorkspaceResource, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]domain.WorkspaceResource), args.Error(1)
+}
+
+type mockWorkspaceCostManager struct {
+	mock.Mock
+}
+
+func (m *mockWorkspaceCostManager) GetResourcesCost(
+	ctx context.Context,
+	resource domain.WorkspaceResources,
+	startTime, endTime time.Time,
+) ([]domain.ResourceCost, error) {
+	args := m.Called(ctx, resource, startTime, endTime)
+	return args.Get(0).([]domain.ResourceCost), args.Error(1)
+}
+
+func setupRouter(explorer *mockAccountExplorer) *Router {
+	return NewWorkspaceRouter(explorer)
+}
+
+func TestListWorkspaces(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupMock      func(*mockAccountExplorer)
+		expectedStatus int
+		expectedBody   []api.Workspace
+	}{
+		{
+			name: "successful response",
+			setupMock: func(m *mockAccountExplorer) {
+				m.On("ListWorkspaces", mock.Anything).Return(
+					[]domain.Workspace{{Name: "ws1"}, {Name: "ws2"}},
+					nil,
+				)
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody: []api.Workspace{
+				{Name: "ws1"},
+				{Name: "ws2"},
+			},
+		},
+		{
+			name: "empty workspaces list",
+			setupMock: func(m *mockAccountExplorer) {
+				m.On("ListWorkspaces", mock.Anything).Return(
+					[]domain.Workspace{},
+					nil,
+				)
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   []api.Workspace{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accountExplorer := new(mockAccountExplorer)
+			tt.setupMock(accountExplorer)
+			router := setupRouter(accountExplorer)
+
+			req := httptest.NewRequest("GET", "/workspaces", nil)
+			rec := httptest.NewRecorder()
+
+			router.ListWorkspaces(rec, req)
+
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+
+			var response []api.Workspace
+			err := json.NewDecoder(rec.Body).Decode(&response)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedBody, response)
+
+			accountExplorer.AssertExpectations(t)
+		})
+	}
+}
+
+func TestListResources(t *testing.T) {
+	tests := []struct {
+		name           string
+		workspace      string
+		setupMock      func(*mockAccountExplorer, *mockWorkspaceExplorer)
+		expectedStatus int
+		expectedBody   []api.WorkspaceResource
+	}{
+		{
+			name:      "successful response",
+			workspace: "test-workspace",
+			setupMock: func(me *mockAccountExplorer, wsExplorer *mockWorkspaceExplorer) {
+				me.On("GetWorkspaceExplorer", mock.Anything, domain.Workspace{Name: "test-workspace"}).
+					Return(wsExplorer, nil)
+				wsExplorer.On("ListSupportedResources", mock.Anything).Return(
+					[]domain.WorkspaceResource{
+						{WorkspaceName: "test-workspace", ResourceName: "warehouse"},
+						{WorkspaceName: "test-workspace", ResourceName: "cluster"},
+					},
+					nil,
+				)
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody: []api.WorkspaceResource{
+				{Name: "warehouse"},
+				{Name: "cluster"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accExplorer := new(mockAccountExplorer)
+			wsExplorer := new(mockWorkspaceExplorer)
+			tt.setupMock(accExplorer, wsExplorer)
+
+			router := setupRouter(accExplorer)
+			req := httptest.NewRequest("GET", "/workspaces/"+tt.workspace+"/resources", nil)
+			rec := httptest.NewRecorder()
+
+			// Set up chi context with URL parameters
+			ctx := chi.NewRouteContext()
+			ctx.URLParams.Add("workspace", tt.workspace)
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, ctx))
+
+			router.ListResources(rec, req)
+
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+
+			var response []api.WorkspaceResource
+			err := json.NewDecoder(rec.Body).Decode(&response)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedBody, response)
+
+			accExplorer.AssertExpectations(t)
+			wsExplorer.AssertExpectations(t)
+		})
+	}
+}
+func TestGetResourceCost(t *testing.T) {
+	startTimeTest := time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC)
+	endTimeTest := time.Date(2025, 7, 13, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name           string
+		workspace      string
+		resource       string
+		queryParams    map[string]string
+		setupMock      func(*mockAccountExplorer, *mockWorkspaceCostManager)
+		expectedStatus int
+		expectedBody   []api.ResourceCost
+	}{
+		{
+			name:      "successful response",
+			workspace: "test-workspace",
+			resource:  "warehouse",
+			queryParams: map[string]string{
+				"from": "01-07-2025",
+				"to":   "13-07-2025",
+			},
+			setupMock: func(me *mockAccountExplorer, cm *mockWorkspaceCostManager) {
+				me.On("GetWorkspaceCostManager", mock.Anything, domain.Workspace{Name: "test-workspace"}).
+					Return(cm, nil)
+
+				cm.On("GetResourcesCost",
+					mock.Anything,
+					domain.WorkspaceResources{
+						WorkspaceName: "test-workspace",
+						Resources:     []string{"warehouse"},
+					},
+					startTimeTest,
+					endTimeTest,
+				).Return([]domain.ResourceCost{
+					{
+						StartTime: startTimeTest,
+						EndTime:   endTimeTest,
+						Resource: domain.ResourceDef{
+							Platform:    "Databricks",
+							Service:     "SQL",
+							Name:        "warehouse",
+							Description: "Databricks SQL Warehouse",
+							Metadata: map[string]string{
+								"warehouse_id": "test-id",
+							},
+						},
+						Costs: []domain.CostComponent{
+							{
+								Type:        "compute",
+								Value:       2.0,
+								Unit:        "DBU",
+								TotalAmount: 4.0,
+								Rate:        2.0,
+								Currency:    "USD",
+								Description: "Compute usage",
+							},
+							{
+								Type:        "storage",
+								Value:       100.0,
+								Unit:        "GB",
+								TotalAmount: 10.0,
+								Rate:        0.1,
+								Currency:    "USD",
+								Description: "Storage usage",
+							},
+						},
+					},
+				}, nil)
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody: []api.ResourceCost{
+				{
+					StartTime: startTimeTest,
+					EndTime:   endTimeTest,
+					Resource: api.ResourceDef{
+						Platform:    "Databricks",
+						Service:     "SQL",
+						Name:        "warehouse",
+						Description: "Databricks SQL Warehouse",
+						Metadata: map[string]string{
+							"warehouse_id": "test-id",
+						},
+					},
+					Costs: []api.CostComponent{
+						{
+							Type:        "compute",
+							Value:       2.0,
+							Unit:        "DBU",
+							TotalAmount: 4.0,
+							Rate:        2.0,
+							Currency:    "USD",
+							Description: "Compute usage",
+						},
+						{
+							Type:        "storage",
+							Value:       100.0,
+							Unit:        "GB",
+							TotalAmount: 10.0,
+							Rate:        0.1,
+							Currency:    "USD",
+							Description: "Storage usage",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "invalid date format",
+			workspace: "test-workspace",
+			resource:  "warehouse",
+			queryParams: map[string]string{
+				"from": "invalid-date",
+			},
+			setupMock: func(me *mockAccountExplorer, cm *mockWorkspaceCostManager) {
+				// No mocks needed for this case
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:      "cost manager error",
+			workspace: "test-workspace",
+			resource:  "warehouse",
+			queryParams: map[string]string{
+				"from": "01-07-2025",
+				"to":   "13-07-2025",
+			},
+			setupMock: func(me *mockAccountExplorer, cm *mockWorkspaceCostManager) {
+				me.On("GetWorkspaceCostManager", mock.Anything, domain.Workspace{Name: "test-workspace"}).
+					Return(nil, fmt.Errorf("workspace not found"))
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExplorer := new(mockAccountExplorer)
+			mockCostManager := new(mockWorkspaceCostManager)
+			tt.setupMock(mockExplorer, mockCostManager)
+
+			router := setupRouter(mockExplorer)
+
+			// Build URL with query parameters
+			url := "/workspaces/" + tt.workspace + "/" + tt.resource + "/cost"
+			if len(tt.queryParams) > 0 {
+				first := true
+				for k, v := range tt.queryParams {
+					if first {
+						url += "?"
+						first = false
+					} else {
+						url += "&"
+					}
+					url += k + "=" + v
+				}
+			}
+
+			req := httptest.NewRequest("GET", url, nil)
+			rec := httptest.NewRecorder()
+
+			// Set up chi context with URL parameters
+			ctx := chi.NewRouteContext()
+			ctx.URLParams.Add("workspace", tt.workspace)
+			ctx.URLParams.Add("resource", tt.resource)
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, ctx))
+
+			router.GetResourceCost(rec, req)
+
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+
+			if tt.expectedStatus == http.StatusOK {
+				var response []api.ResourceCost
+				err := json.NewDecoder(rec.Body).Decode(&response)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedBody, response)
+			}
+
+			mockExplorer.AssertExpectations(t)
+			mockCostManager.AssertExpectations(t)
+		})
+	}
+}
+
+func TestParseDataParam(t *testing.T) {
+	tests := []struct {
+		name         string
+		paramName    string
+		paramValue   string
+		defaultDate  time.Time
+		expectedDate time.Time
+		expectError  bool
+	}{
+		{
+			name:         "valid date",
+			paramName:    "from",
+			paramValue:   "13-07-2025",
+			defaultDate:  time.Now(),
+			expectedDate: time.Date(2025, 7, 13, 0, 0, 0, 0, time.UTC),
+			expectError:  false,
+		},
+		{
+			name:         "invalid date format",
+			paramName:    "from",
+			paramValue:   "2025-07-13",
+			defaultDate:  time.Now(),
+			expectedDate: time.Time{},
+			expectError:  true,
+		},
+		{
+			name:         "empty date",
+			paramName:    "from",
+			paramValue:   "",
+			defaultDate:  time.Date(2025, 7, 13, 0, 0, 0, 0, time.UTC),
+			expectedDate: time.Date(2025, 7, 13, 0, 0, 0, 0, time.UTC),
+			expectError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/?"+tt.paramName+"="+tt.paramValue, nil)
+			result, err := parseDateParam(req, tt.paramName, tt.defaultDate)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedDate, result)
+			}
+		})
+	}
+}

--- a/pkg/models/domain/config.go
+++ b/pkg/models/domain/config.go
@@ -1,6 +1,8 @@
 package domain
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type ProfileType string
 

--- a/pkg/models/domain/cost.go
+++ b/pkg/models/domain/cost.go
@@ -22,8 +22,8 @@ type ResourceDef struct {
 }
 
 type ResourceCost struct {
-	StartTime time.Time // 12.03.25
-	EndTime   time.Time // 14.03.25
+	StartTime time.Time
+	EndTime   time.Time
 	Resource  ResourceDef
 	Costs     []CostComponent
 }

--- a/pkg/models/domain/workspace.go
+++ b/pkg/models/domain/workspace.go
@@ -8,3 +8,8 @@ type WorkspaceResource struct {
 	WorkspaceName string
 	ResourceName  string
 }
+
+type WorkspaceResources struct {
+	WorkspaceName string
+	Resources     []string
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -25,8 +25,6 @@ type Config struct {
 }
 
 func ConfigureRouter(config Config) *chi.Mux {
-	wsHandler := handlers.NewHandler(config.Dependencies.Account)
-
 	router := chi.NewRouter()
 
 	router.Use(dataatlasmiddleware.Logger(&config.Dependencies.Logger))
@@ -36,11 +34,8 @@ func ConfigureRouter(config Config) *chi.Mux {
 		w.Write([]byte("hello world"))
 	})
 
-	router.Route("/api/v1", func(r chi.Router) {
-		r.Get("/workspaces", wsHandler.ListWorkspaces)
-		r.Get("/workspaces/{workspace}/resources", wsHandler.ListResources)
-		r.Get("/workspaces/{workspace}/{resource}/cost", wsHandler.GetResourceCost)
-	})
+	workspaces := handlers.NewWorkspaceRouter(config.Dependencies.Account)
+	router.Mount("/api/v1", workspaces.Routes())
 
 	return router
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,268 +1,85 @@
 package server
 
 import (
-	"context"
-	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
-	"github.com/de-tools/data-atlas/pkg/services/account/workspace"
-
-	"github.com/de-tools/data-atlas/pkg/models/api"
-	"github.com/de-tools/data-atlas/pkg/models/domain"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
-type mockExplorer struct {
-	mock.Mock
-}
-
-func (m *mockExplorer) ListWorkspaces(ctx context.Context) ([]domain.Workspace, error) {
-	args := m.Called(ctx)
-	return args.Get(0).([]domain.Workspace), args.Error(1)
-}
-
-func (m *mockExplorer) GetWorkspaceExplorer(ctx context.Context, ws domain.Workspace) (workspace.Explorer, error) {
-	args := m.Called(ctx, ws)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(workspace.Explorer), args.Error(1)
-}
-
-func (m *mockExplorer) GetWorkspaceCostManager(
-	ctx context.Context,
-	ws domain.Workspace,
-) (workspace.CostManager, error) {
-	args := m.Called(ctx, ws)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(workspace.CostManager), args.Error(1)
-}
-
-type mockWorkspaceExplorer struct {
-	mock.Mock
-}
-
-func (m *mockWorkspaceExplorer) ListSupportedResources(ctx context.Context) ([]domain.WorkspaceResource, error) {
-	args := m.Called(ctx)
-	return args.Get(0).([]domain.WorkspaceResource), args.Error(1)
-}
-
-type mockWorkspaceCostManager struct {
-	mock.Mock
-}
-
-func (m *mockWorkspaceCostManager) GetResourceCost(
-	ctx context.Context,
-	resource domain.WorkspaceResource,
-	startTime, endTime time.Time,
-) ([]domain.ResourceCost, error) {
-	args := m.Called(ctx, resource, startTime, endTime)
-	return args.Get(0).([]domain.ResourceCost), args.Error(1)
-}
-
-func TestWebAPI_Endpoints(t *testing.T) {
-	logger := zerolog.New(zerolog.NewTestWriter(nil))
-
-	mockExp := new(mockExplorer)
-	mockWsExp := new(mockWorkspaceExplorer)
-	mockCostMgr := new(mockWorkspaceCostManager)
-
-	config := Config{
-		Addr:            ":8080",
-		ShutdownTimeout: 10 * time.Second,
-		Dependencies: Dependencies{
-			Account: mockExp,
-			Logger:  logger,
-		},
-	}
-	router := ConfigureRouter(config)
-	testServer := httptest.NewServer(router)
-	defer testServer.Close()
-
-	expectedStartTime, _ := time.Parse("2006-01-02", "2025-06-13")
-	expectedEndTime, _ := time.Parse("2006-01-02", "2025-06-20")
-
+func TestConfigureRouter(t *testing.T) {
 	tests := []struct {
 		name           string
 		path           string
-		setupMocks     func()
 		expectedStatus int
-		expected       interface{}
-		parseResponse  func([]byte) (interface{}, error)
 	}{
 		{
-			name: "ListWorkspaces",
-			path: "/api/v1/workspaces",
-			setupMocks: func() {
-				mockExp.On("ListWorkspaces", mock.Anything).
-					Return([]domain.Workspace{{Name: "default"}}, nil)
-			},
+			name:           "root endpoint",
+			path:           "/",
 			expectedStatus: http.StatusOK,
-			expected:       []api.Workspace{{Name: "default"}},
-			parseResponse:  unmarshalResponse[[]api.Workspace](),
 		},
 		{
-			name: "ListResources",
-			path: "/api/v1/workspaces/default/resources",
-			setupMocks: func() {
-				mockExp.On("GetWorkspaceExplorer", mock.Anything, domain.Workspace{Name: "default"}).
-					Return(mockWsExp, nil)
-				mockWsExp.On("ListSupportedResources", mock.Anything).
-					Return([]domain.WorkspaceResource{{ResourceName: "warehouse"}}, nil)
-			},
-			expectedStatus: http.StatusOK,
-			expected:       []api.WorkspaceResource{{Name: "warehouse"}},
-			parseResponse:  unmarshalResponse[[]api.WorkspaceResource](),
-		},
-		{
-			name: "GetResourceCost",
-			path: "/api/v1/workspaces/default/warehouse/cost?from=2025-06-13&to=2025-06-20",
-			setupMocks: func() {
-				mockExp.On("GetWorkspaceCostManager", mock.Anything, domain.Workspace{Name: "default"}).
-					Return(mockCostMgr, nil)
-				mockCostMgr.On("GetResourceCost",
-					mock.Anything,
-					domain.WorkspaceResource{
-						WorkspaceName: "default",
-						ResourceName:  "warehouse",
-					},
-					expectedStartTime,
-					expectedEndTime,
-				).Return([]domain.ResourceCost{{
-					StartTime: expectedStartTime,
-					EndTime:   expectedEndTime,
-					Resource: domain.ResourceDef{
-						Platform:    "Databricks",
-						Service:     "warehouse",
-						Name:        "warehouse",
-						Description: "Mock resource in default",
-						Metadata:    map[string]string{},
-					},
-					Costs: []domain.CostComponent{{
-						Type:        "compute",
-						Value:       2,
-						Unit:        "hours",
-						TotalAmount: 0.0084,
-						Rate:        0.0042,
-						Currency:    "USD",
-						Description: "Mock cost data",
-					}},
-				}}, nil)
-			},
-			expectedStatus: http.StatusOK,
-			expected: []api.ResourceCost{{
-				StartTime: expectedStartTime,
-				EndTime:   expectedEndTime,
-				Resource: api.ResourceDef{
-					Platform:    "Databricks",
-					Service:     "warehouse",
-					Name:        "warehouse",
-					Description: "Mock resource in default",
-					Metadata:    map[string]string{},
-				},
-				Costs: []api.CostComponent{{
-					Type:        "compute",
-					Value:       2,
-					Unit:        "hours",
-					TotalAmount: 0.0084,
-					Rate:        0.0042,
-					Currency:    "USD",
-					Description: "Mock cost data",
-				}},
-			}},
-			parseResponse: unmarshalResponse[[]api.ResourceCost](),
-		},
-		{
-			name: "GetResourceCost_InvalidFromDate",
-			path: "/api/v1/workspaces/default/warehouse/cost?from=invalid-date",
-			setupMocks: func() {
-				mockExp.On("GetWorkspaceCostManager", mock.Anything, domain.Workspace{Name: "default"}).
-					Return(mockCostMgr, nil)
-			},
-			expectedStatus: http.StatusBadRequest,
-			expected:       "invalid 'from' date format. Expected format: YYYY-MM-DD\n",
-			parseResponse: func(data []byte) (interface{}, error) {
-				return string(data), nil
-			},
-		},
-		{
-			name: "GetResourceCost_InvalidToDate",
-			path: "/api/v1/workspaces/default/warehouse/cost?to=invalid-date",
-			setupMocks: func() {
-				mockExp.On("GetWorkspaceCostManager", mock.Anything, domain.Workspace{Name: "default"}).
-					Return(mockCostMgr, nil)
-			},
-			expectedStatus: http.StatusBadRequest,
-			expected:       "invalid 'to' date format. Expected format: YYYY-MM-DD\n",
-			parseResponse: func(data []byte) (interface{}, error) {
-				return string(data), nil
-			},
-		},
-		{
-			name: "GetResourceCost_DefaultDates",
-			path: "/api/v1/workspaces/default/warehouse/cost",
-			setupMocks: func() {
-				mockExp.On("GetWorkspaceCostManager", mock.Anything, domain.Workspace{Name: "default"}).
-					Return(mockCostMgr, nil)
-
-				now := time.Now()
-				startTime := now.AddDate(0, 0, -7)
-
-				mockCostMgr.On("GetResourceCost",
-					mock.Anything,
-					domain.WorkspaceResource{
-						WorkspaceName: "default",
-						ResourceName:  "warehouse",
-					},
-					mock.MatchedBy(func(t time.Time) bool {
-						// Match the start time within a day to account for test execution time
-						return t.Sub(startTime).Hours() < 24
-					}),
-					mock.MatchedBy(func(t time.Time) bool {
-						// Match the end time within a day
-						return now.Sub(t).Hours() < 24
-					}),
-				).Return([]domain.ResourceCost{}, nil)
-			},
-			expectedStatus: http.StatusOK,
-			expected:       []api.ResourceCost{},
-			parseResponse:  unmarshalResponse[[]api.ResourceCost](),
+			name:           "non-existent endpoint",
+			path:           "/not-found",
+			expectedStatus: http.StatusNotFound,
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			tc.setupMocks()
-			resp, err := http.Get(testServer.URL + tc.path)
-			require.NoError(t, err, "Failed to send request")
-			defer resp.Body.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := Config{
+				Addr:            ":8080",
+				ShutdownTimeout: 5 * time.Second,
+				Dependencies: Dependencies{
+					Logger: zerolog.New(zerolog.NewTestWriter(t)),
+				},
+			}
 
-			assert.Equal(t, tc.expectedStatus, resp.StatusCode, "Status code mismatch")
+			router := ConfigureRouter(config)
 
-			body, err := io.ReadAll(resp.Body)
-			require.NoError(t, err, "Failed to read response body")
+			req := httptest.NewRequest("GET", tt.path, nil)
+			rec := httptest.NewRecorder()
 
-			actual, err := tc.parseResponse(body)
-			require.NoError(t, err, "Failed to parse response")
+			router.ServeHTTP(rec, req)
 
-			assert.Equal(t, tc.expected, actual)
+			assert.Equal(t, tt.expectedStatus, rec.Code)
 		})
 	}
 }
 
-func unmarshalResponse[T any]() func([]byte) (interface{}, error) {
-	return func(data []byte) (interface{}, error) {
-		var response T
-		err := json.Unmarshal(data, &response)
-		return response, err
+func TestRouterMiddlewares(t *testing.T) {
+	config := Config{
+		Addr:            ":8080",
+		ShutdownTimeout: 5 * time.Second,
+		Dependencies: Dependencies{
+			Logger: zerolog.New(zerolog.NewTestWriter(t)),
+		},
 	}
+
+	router := ConfigureRouter(config)
+
+	t.Run("recoverer middleware handles panic", func(t *testing.T) {
+		router.Get("/panic", func(w http.ResponseWriter, r *http.Request) {
+			panic("test panic")
+		})
+
+		req := httptest.NewRequest("GET", "/panic", nil)
+		rec := httptest.NewRecorder()
+
+		router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	})
+
+	t.Run("logger middleware is present", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+
+		router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
 }

--- a/pkg/services/account/workspace/cost.go
+++ b/pkg/services/account/workspace/cost.go
@@ -29,7 +29,11 @@ func NewCostManager(usageStore usage.Store) CostManager {
 	}
 }
 
-func (w *workspaceCostManager) GetResourcesCost(ctx context.Context, res domain.WorkspaceResources, startTime, endTime time.Time) ([]domain.ResourceCost, error) {
+func (w *workspaceCostManager) GetResourcesCost(
+	ctx context.Context,
+	res domain.WorkspaceResources,
+	startTime, endTime time.Time,
+) ([]domain.ResourceCost, error) {
 	if !startTime.Before(endTime) {
 		return nil, fmt.Errorf("invalid time range: start time (%s) must be before end time (%s)",
 			startTime.Format("2006-01-02"),

--- a/pkg/services/account/workspace/cost.go
+++ b/pkg/services/account/workspace/cost.go
@@ -12,9 +12,9 @@ import (
 )
 
 type CostManager interface {
-	GetResourceCost(
+	GetResourcesCost(
 		ctx context.Context,
-		res domain.WorkspaceResource,
+		res domain.WorkspaceResources,
 		startTime, endTime time.Time,
 	) ([]domain.ResourceCost, error)
 }
@@ -29,18 +29,14 @@ func NewCostManager(usageStore usage.Store) CostManager {
 	}
 }
 
-func (w *workspaceCostManager) GetResourceCost(
-	ctx context.Context,
-	res domain.WorkspaceResource,
-	startTime, endTime time.Time,
-) ([]domain.ResourceCost, error) {
+func (w *workspaceCostManager) GetResourcesCost(ctx context.Context, res domain.WorkspaceResources, startTime, endTime time.Time) ([]domain.ResourceCost, error) {
 	if !startTime.Before(endTime) {
 		return nil, fmt.Errorf("invalid time range: start time (%s) must be before end time (%s)",
 			startTime.Format("2006-01-02"),
 			endTime.Format("2006-01-02"))
 	}
 
-	records, err := w.usageStore.GetResourceUsage(ctx, res.ResourceName, startTime, endTime)
+	records, err := w.usageStore.GetResourcesUsage(ctx, res.Resources, startTime, endTime)
 	if err != nil {
 		return nil, err
 	}
@@ -49,5 +45,6 @@ func (w *workspaceCostManager) GetResourceCost(
 	for _, record := range records {
 		costs = append(costs, adapters.MapStoreUsageRecordToDomainCost(record))
 	}
+
 	return costs, nil
 }

--- a/pkg/services/account/workspace/cost.go
+++ b/pkg/services/account/workspace/cost.go
@@ -36,7 +36,8 @@ func (w *workspaceCostManager) GetResourcesCost(ctx context.Context, res domain.
 			endTime.Format("2006-01-02"))
 	}
 
-	records, err := w.usageStore.GetResourcesUsage(ctx, res.Resources, startTime, endTime)
+	resourceTypes := validResourceTypes(res.Resources)
+	records, err := w.usageStore.GetResourcesUsage(ctx, resourceTypes, startTime, endTime)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/account/workspace/explorer.go
+++ b/pkg/services/account/workspace/explorer.go
@@ -8,6 +8,26 @@ import (
 	"github.com/de-tools/data-atlas/pkg/models/domain"
 )
 
+var SupportedResources = map[string]string{
+	"sharing_materialization": "sharing_materialization_id",
+	"central_clean_room":      "central_clean_room_id",
+	"budget_policy":           "budget_policy_id",
+	"job":                     "job_id",
+	"job_run":                 "job_run_id",
+	"dlt_update":              "dlt_update_id",
+	"dlt_maintenance":         "dlt_maintenance_id",
+	"instance_pool":           "instance_pool_id",
+	"app":                     "app_id",
+	"database_instance":       "database_instance_id",
+	"ai_runtime_pool":         "ai_runtime_pool_id",
+	"cluster":                 "cluster_id",
+	"endpoint":                "endpoint_id",
+	"warehouse":               "warehouse_id",
+	"source":                  "source_region",
+	"dlt_pipeline":            "dlt_pipeline_id",
+	"metastore":               "metastore_id",
+}
+
 type Explorer interface {
 	ListSupportedResources(ctx context.Context) ([]domain.WorkspaceResource, error)
 }
@@ -24,9 +44,19 @@ func NewExplorer(config *config.Config, ws domain.Workspace) Explorer {
 func (w *workspaceExplorer) ListSupportedResources(
 	_ context.Context,
 ) ([]domain.WorkspaceResource, error) {
-	return []domain.WorkspaceResource{
-		{WorkspaceName: w.ws.Name, ResourceName: "warehouse"},
-		{WorkspaceName: w.ws.Name, ResourceName: "cluster"},
-		{WorkspaceName: w.ws.Name, ResourceName: "job"},
-	}, nil
+	var resources []domain.WorkspaceResource
+	for resourceName, _ := range SupportedResources {
+		resources = append(resources, domain.WorkspaceResource{WorkspaceName: w.ws.Name, ResourceName: resourceName})
+	}
+	return resources, nil
+}
+
+func validResourceTypes(types []string) []string {
+	var supportedTypes []string
+	for _, rt := range types {
+		if _, ok := SupportedResources[rt]; ok {
+			supportedTypes = append(supportedTypes, rt)
+		}
+	}
+	return supportedTypes
 }

--- a/pkg/services/config/databrickscfg.go
+++ b/pkg/services/config/databrickscfg.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"fmt"
+
 	databricksconfig "github.com/databricks/databricks-sdk-go/config"
 	"github.com/de-tools/data-atlas/pkg/models/domain"
 	"github.com/rs/zerolog"

--- a/pkg/services/config/databrickscfg.go
+++ b/pkg/services/config/databrickscfg.go
@@ -51,9 +51,7 @@ func (cr *CfgRegistry) Init(ctx context.Context) error {
 			}
 
 			profile := domain.ConfigProfile{Name: profileName, Type: domain.ProfileTypeWorkspace}
-			if cfg, exists := cr.profileMap[profile]; !exists {
-				cr.profileMap[profile] = cfg
-			}
+			cr.profileMap[profile] = cfg
 		}
 	}
 	return nil
@@ -68,8 +66,10 @@ func (cr *CfgRegistry) GetProfiles(_ context.Context) ([]domain.ConfigProfile, e
 }
 
 func (cr *CfgRegistry) GetConfig(_ context.Context, profile domain.ConfigProfile) (*databricksconfig.Config, error) {
-	if cfg, exists := cr.profileMap[profile]; exists {
-		return cfg, nil
+	for key, value := range cr.profileMap {
+		if key.Name == profile.Name && key.Type == profile.Type {
+			return value, nil
+		}
 	}
 
 	return nil, fmt.Errorf("profile %s not found in %s", profile, cr.path)
@@ -90,6 +90,11 @@ func (cr *CfgRegistry) loadConfig(_ context.Context, profile string) (*databrick
 
 	if err != nil {
 		return nil, fmt.Errorf("%s %s profile: %w", cr.path, profile, err)
+	}
+
+	err = cfg.EnsureResolved()
+	if err != nil {
+		return nil, fmt.Errorf("ensuring config resolution for profile %s: %w", profile, err)
 	}
 
 	return cfg, nil

--- a/pkg/store/usage/store.go
+++ b/pkg/store/usage/store.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"sort"
+	"strings"
 	"time"
 
 	"github.com/de-tools/data-atlas/pkg/store/pricing"
@@ -14,24 +14,12 @@ import (
 )
 
 type Store interface {
-	GetResourceUsage(
+	GetResourcesUsage(
 		ctx context.Context,
-		resource string,
+		resource []string,
 		startTime time.Time,
 		endTime time.Time,
 	) ([]store.UsageRecord, error)
-	GetDailyUsage(
-		ctx context.Context,
-		resource string,
-		startTime time.Time,
-		endTime time.Time,
-	) ([]store.DailyUsageAggregate, error)
-	GetMonthlyUsage(
-		ctx context.Context,
-		resource string,
-		startTime time.Time,
-		endTime time.Time,
-	) ([]store.MonthlyUsageAggregate, error)
 }
 
 type usageStore struct {
@@ -49,35 +37,42 @@ func NewStore(
 	}
 }
 
-func (u *usageStore) GetResourceUsage(
-	ctx context.Context,
-	resource string,
-	startTime time.Time,
-	endTime time.Time,
-) ([]store.UsageRecord, error) {
+func (u *usageStore) GetResourcesUsage(ctx context.Context, resources []string, startTime time.Time, endTime time.Time) ([]store.UsageRecord, error) {
 	logger := zerolog.Ctx(ctx)
-	id := fmt.Sprintf("%s_id", resource)
-	query := fmt.Sprintf(`
+
+	var conditions []string
+	for _, resourceType := range resources {
+		idField := fmt.Sprintf("usage_metadata.%s_id", resourceType)
+		conditions = append(conditions, fmt.Sprintf("%s IS NOT NULL", idField))
+	}
+
+	query := `
 		SELECT
-		  usage_metadata.%[1]s    AS id,
-		  usage_start_time,
-		  usage_end_time,
-		  usage_quantity,
-		  usage_unit,
-		  sku_name
+			COALESCE(` + buildCoalesceList(resources, "_id") + `) AS id,
+			(
+				CASE
+					` + buildResourceTypeCase(resources) + `
+					ELSE 'unknown'
+				END
+			) AS resource_type,
+			usage_start_time,
+			usage_end_time,
+			usage_quantity,
+			usage_unit,
+			sku_name
 		FROM system.billing.usage
-		WHERE usage_metadata.%[1]s IS NOT NULL
-		  AND usage_start_time >= timestamp(?)
-		  AND usage_start_time < timestamp(?)
+		WHERE (` + strings.Join(conditions, " OR ") + `)
+			AND usage_start_time >= ?
+			AND usage_start_time < ?
 		ORDER BY usage_start_time DESC
-	`, id)
+	`
 
 	startTimeFormatted := startTime.Format("2006-01-02 15:04:05")
 	endTimeFormatted := endTime.Format("2006-01-02 15:04:05")
 
 	rows, err := u.db.Query(query, startTimeFormatted, endTimeFormatted)
 	if err != nil {
-		return nil, fmt.Errorf("%s usage query failed: %w", resource, err)
+		return nil, fmt.Errorf("usage query failed: %w", err)
 	}
 	defer func(rows *sql.Rows) {
 		err := rows.Close()
@@ -89,19 +84,21 @@ func (u *usageStore) GetResourceUsage(
 	var records []store.UsageRecord
 	for rows.Next() {
 		var (
-			id, unit, sku string
-			start, end    time.Time
-			qty           float64
+			id, resourceType, unit, sku string
+			start, end                  time.Time
+			qty                         float64
 		)
-		if err := rows.Scan(&id, &start, &end, &qty, &unit, &sku); err != nil {
+		if err := rows.Scan(&id, &resourceType, &start, &end, &qty, &unit, &sku); err != nil {
 			return nil, err
 		}
 
 		price := u.pricingStore.GetSkuPrice(ctx, sku)
 
 		records = append(records, store.UsageRecord{
-			ID:        id,
-			Metadata:  map[string]string{},
+			ID: id,
+			Metadata: map[string]string{
+				"resource_type": resourceType,
+			},
 			StartTime: start,
 			EndTime:   end,
 			Quantity:  qty,
@@ -115,177 +112,18 @@ func (u *usageStore) GetResourceUsage(
 	return records, nil
 }
 
-func (u *usageStore) GetDailyUsage(
-	ctx context.Context,
-	resource string,
-	startTime time.Time,
-	endTime time.Time,
-) ([]store.DailyUsageAggregate, error) {
-	logger := zerolog.Ctx(ctx)
-	id := fmt.Sprintf("%s_id", resource)
-	query := fmt.Sprintf(`
-		SELECT
-            usage_date,
-            SUM(usage_quantity) as total_usage,
-            usage_unit,
-            sku_name,
-            COUNT(*) as record_count
-        FROM system.billing.usage
-        WHERE usage_metadata.%[1]s IS NOT NULL
-            AND usage_date >= ?1
-            AND usage_date < ?2
-        GROUP BY 
-            usage_date,
-            usage_unit,
-            sku_name
-        ORDER BY usage_date DESC
-    `, id)
-
-	startTimeFormatted := startTime.Format("2006-01-02 15:04:05")
-	endTimeFormatted := endTime.Format("2006-01-02 15:04:05")
-
-	rows, err := u.db.Query(query, startTimeFormatted, endTimeFormatted)
-	if err != nil {
-		return nil, fmt.Errorf("aggregated %s usage query failed: %w", resource, err)
+func buildCoalesceList(resourceTypes []string, suffix string) string {
+	var fields []string
+	for _, rt := range resourceTypes {
+		fields = append(fields, fmt.Sprintf("usage_metadata.%s%s", rt, suffix))
 	}
-
-	defer func(rows *sql.Rows) {
-		err := rows.Close()
-		if err != nil {
-			logger.Warn().Err(err).Msg("failed to close aggregated usage query rows")
-		}
-	}(rows)
-
-	dailyAggregates := make(map[time.Time]*store.DailyUsageAggregate)
-
-	for rows.Next() {
-		var (
-			usageDate   time.Time
-			totalUsage  float64
-			unit, sku   string
-			recordCount int
-		)
-		if err := rows.Scan(&usageDate, &totalUsage, &unit, &sku, &recordCount); err != nil {
-			return nil, fmt.Errorf("failed to scan aggregated usage row: %w", err)
-		}
-
-		price := u.pricingStore.GetSkuPrice(ctx, sku)
-		totalCost := totalUsage * price.PricePerUnit
-		agg, exists := dailyAggregates[usageDate]
-		if !exists {
-			agg = &store.DailyUsageAggregate{
-				Date:     usageDate,
-				Resource: resource,
-				Unit:     unit,
-				Currency: price.CurrencyCode,
-			}
-			dailyAggregates[usageDate] = agg
-		}
-
-		agg.TotalUsage += totalUsage
-		agg.TotalCost += totalCost
-	}
-
-	var result []store.DailyUsageAggregate
-	for _, agg := range dailyAggregates {
-		result = append(result, *agg)
-	}
-
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].Date.After(result[j].Date)
-	})
-
-	return result, nil
+	return strings.Join(fields, ", ")
 }
 
-func (u *usageStore) GetMonthlyUsage(
-	ctx context.Context,
-	resource string,
-	startTime time.Time,
-	endTime time.Time,
-) ([]store.MonthlyUsageAggregate, error) {
-	logger := zerolog.Ctx(ctx)
-	id := fmt.Sprintf("%s_id", resource)
-
-	query := fmt.Sprintf(`
-        SELECT
-            YEAR(usage_date) as year,
-            MONTH(usage_date) as month,
-            SUM(usage_quantity) as total_usage,
-            usage_unit,
-            sku_name,
-            COUNT(*) as record_count
-        FROM system.billing.usage
-        WHERE usage_metadata.%[1]s IS NOT NULL
-            AND usage_date >= ?1
-            AND usage_date < ?2
-        GROUP BY 
-            YEAR(usage_date),
-            MONTH(usage_date),
-            usage_unit,
-            sku_name
-        ORDER BY year DESC, month DESC
-    `, id)
-
-	startDateStr := startTime.Format("2006-01-02")
-	endDateStr := endTime.Format("2006-01-02")
-
-	rows, err := u.db.Query(query, startDateStr, endDateStr)
-	if err != nil {
-		return nil, fmt.Errorf("aggregated yearly %s usage query failed: %w", resource, err)
+func buildResourceTypeCase(resourceTypes []string) string {
+	var cases []string
+	for _, rt := range resourceTypes {
+		cases = append(cases, fmt.Sprintf("WHEN usage_metadata.%s_id IS NOT NULL THEN '%s'", rt, rt))
 	}
-	defer func(rows *sql.Rows) {
-		err := rows.Close()
-		if err != nil {
-			logger.Warn().Err(err).Msg("failed to close aggregated usage query rows")
-		}
-	}(rows)
-
-	// Map to store aggregates by year-month
-	monthlyAggregates := make(map[string]*store.MonthlyUsageAggregate)
-
-	for rows.Next() {
-		var (
-			year, month int
-			totalUsage  float64
-			unit, sku   string
-			recordCount int
-		)
-		if err := rows.Scan(&year, &month, &totalUsage, &unit, &sku, &recordCount); err != nil {
-			return nil, fmt.Errorf("failed to scan aggregated usage row: %w", err)
-		}
-
-		key := fmt.Sprintf("%d-%02d", year, month)
-		price := u.pricingStore.GetSkuPrice(ctx, sku)
-		totalCost := totalUsage * price.PricePerUnit
-
-		agg, exists := monthlyAggregates[key]
-		if !exists {
-			agg = &store.MonthlyUsageAggregate{
-				Year:     year,
-				Month:    time.Month(month),
-				Resource: resource,
-				Unit:     unit,
-				Currency: price.CurrencyCode,
-			}
-			monthlyAggregates[key] = agg
-		}
-
-		agg.TotalUsage += totalUsage
-		agg.TotalCost += totalCost
-	}
-
-	var result []store.MonthlyUsageAggregate
-	for _, agg := range monthlyAggregates {
-		result = append(result, *agg)
-	}
-
-	sort.Slice(result, func(i, j int) bool {
-		if result[i].Year != result[j].Year {
-			return result[i].Year > result[j].Year
-		}
-		return result[i].Month > result[j].Month
-	})
-
-	return result, nil
+	return strings.Join(cases, "\n")
 }

--- a/pkg/store/usage/store.go
+++ b/pkg/store/usage/store.go
@@ -37,7 +37,12 @@ func NewStore(
 	}
 }
 
-func (u *usageStore) GetResourcesUsage(ctx context.Context, resources []string, startTime time.Time, endTime time.Time) ([]store.UsageRecord, error) {
+func (u *usageStore) GetResourcesUsage(
+	ctx context.Context,
+	resources []string,
+	startTime time.Time,
+	endTime time.Time,
+) ([]store.UsageRecord, error) {
 	logger := zerolog.Ctx(ctx)
 
 	var conditions []string


### PR DESCRIPTION
- Query cost metric in a resource agnostic way (without specifying a resource type) / resources?type=wh,job,cluster
- added basic resource type validation
- simplified workspace handler
- changed service layer to consume new more generic store version, removed the rest.
Example:
```
/workspaces/{workspace}/metrics/cost?resource_type=cluster&resource_type=warehouse&from=...&to=...
```