### PR TITLE
Unify get usage functions and make api operation the default

### DIFF
--- a/pkg/adapters/cost.go
+++ b/pkg/adapters/cost.go
@@ -16,9 +16,9 @@ func MapStoreUsageRecordToDomainCost(usage store.UsageRecord) domain.ResourceCos
 		EndTime:   usage.EndTime,
 		Resource: domain.ResourceDef{
 			Platform:    "Databricks",
-			Name:        usage.ID,
-			Service:     usage.Resource,
-			Description: fmt.Sprintf("Databricks %s %s", usage.Resource, usage.ID),
+			Name:        usage.ResourceID,
+			Service:     usage.ResourceType,
+			Description: fmt.Sprintf("Databricks %s %s", usage.ResourceType, usage.ResourceID),
 			Metadata:    maps.Clone(usage.Metadata),
 		},
 		Costs: []domain.CostComponent{{
@@ -38,16 +38,17 @@ func MapDomainResourceCostToStoreUsageRecord(cost domain.ResourceCost) store.Usa
 	computeCost := cost.Costs[0]
 
 	return store.UsageRecord{
-		ID:        cost.Resource.Name,
-		Resource:  cost.Resource.Service,
-		StartTime: cost.StartTime,
-		EndTime:   cost.EndTime,
-		Quantity:  computeCost.Value,
-		Unit:      computeCost.Unit,
-		Rate:      computeCost.Rate,
-		Currency:  computeCost.Currency,
-		SKU:       computeCost.SKU,
-		Metadata:  maps.Clone(cost.Resource.Metadata),
+		ID:           cost.ID,
+		ResourceID:   cost.Resource.Name,
+		ResourceType: cost.Resource.Service,
+		StartTime:    cost.StartTime,
+		EndTime:      cost.EndTime,
+		Quantity:     computeCost.Value,
+		Unit:         computeCost.Unit,
+		Rate:         computeCost.Rate,
+		Currency:     computeCost.Currency,
+		SKU:          computeCost.SKU,
+		Metadata:     maps.Clone(cost.Resource.Metadata),
 	}
 }
 

--- a/pkg/models/domain/cost.go
+++ b/pkg/models/domain/cost.go
@@ -1,7 +1,8 @@
 package domain
 
 import (
-	"sort"
+	"maps"
+	"slices"
 	"time"
 )
 
@@ -57,12 +58,4 @@ var SupportedResources = map[string]string{
 	"metastore":               "metastore_id",
 }
 
-var SupportedResourcesList []string
-
-func init() {
-	SupportedResourcesList = make([]string, 0, len(SupportedResources))
-	for k := range SupportedResources {
-		SupportedResourcesList = append(SupportedResourcesList, k)
-	}
-	sort.Strings(SupportedResourcesList)
-}
+var SupportedResourcesList = slices.Collect(maps.Keys(SupportedResources))

--- a/pkg/models/domain/cost.go
+++ b/pkg/models/domain/cost.go
@@ -1,6 +1,9 @@
 package domain
 
-import "time"
+import (
+	"sort"
+	"time"
+)
 
 type UsageStats struct {
 	RecordsCount    int64
@@ -33,4 +36,33 @@ type ResourceCost struct {
 	EndTime   time.Time
 	Resource  ResourceDef
 	Costs     []CostComponent
+}
+
+var SupportedResources = map[string]string{
+	"sharing_materialization": "sharing_materialization_id",
+	"central_clean_room":      "central_clean_room_id",
+	"budget_policy":           "budget_policy_id",
+	"job":                     "job_id",
+	"job_run":                 "job_run_id",
+	"dlt_update":              "dlt_update_id",
+	"dlt_maintenance":         "dlt_maintenance_id",
+	"instance_pool":           "instance_pool_id",
+	"app":                     "app_id",
+	"database_instance":       "database_instance_id",
+	"ai_runtime_pool":         "ai_runtime_pool_id",
+	"cluster":                 "cluster_id",
+	"endpoint":                "endpoint_id",
+	"warehouse":               "warehouse_id",
+	"dlt_pipeline":            "dlt_pipeline_id",
+	"metastore":               "metastore_id",
+}
+
+var SupportedResourcesList []string
+
+func init() {
+	SupportedResourcesList = make([]string, 0, len(SupportedResources))
+	for k := range SupportedResources {
+		SupportedResourcesList = append(SupportedResourcesList, k)
+	}
+	sort.Strings(SupportedResourcesList)
 }

--- a/pkg/models/store/cost.go
+++ b/pkg/models/store/cost.go
@@ -8,16 +8,17 @@ type UsageStats struct {
 }
 
 type UsageRecord struct {
-	ID        string
-	Resource  string
-	Metadata  map[string]string
-	Quantity  float64
-	Unit      string
-	SKU       string
-	Rate      float64
-	Currency  string
-	StartTime time.Time
-	EndTime   time.Time
+	ID           string
+	ResourceID   string
+	ResourceType string
+	Metadata     map[string]string
+	Quantity     float64
+	Unit         string
+	SKU          string
+	Rate         float64
+	Currency     string
+	StartTime    time.Time
+	EndTime      time.Time
 }
 
 type DailyUsageAggregate struct {

--- a/pkg/services/account/workspace/cost.go
+++ b/pkg/services/account/workspace/cost.go
@@ -55,7 +55,7 @@ func (w *workspaceCostManager) GetResourcesCost(
 
 	var records []store.UsageRecord
 	var err error
-	// Case when we call /metrics/cost without resources
+	// Case when we call /resources/cost without resources
 	if len(resourceTypes) == 0 {
 		records, err = w.usageStore.GetUsage(ctx, startTime, endTime)
 	} else {

--- a/pkg/services/account/workspace/explorer.go
+++ b/pkg/services/account/workspace/explorer.go
@@ -8,25 +8,6 @@ import (
 	"github.com/de-tools/data-atlas/pkg/models/domain"
 )
 
-var SupportedResources = map[string]string{
-	"sharing_materialization": "sharing_materialization_id",
-	"central_clean_room":      "central_clean_room_id",
-	"budget_policy":           "budget_policy_id",
-	"job":                     "job_id",
-	"job_run":                 "job_run_id",
-	"dlt_update":              "dlt_update_id",
-	"dlt_maintenance":         "dlt_maintenance_id",
-	"instance_pool":           "instance_pool_id",
-	"app":                     "app_id",
-	"database_instance":       "database_instance_id",
-	"ai_runtime_pool":         "ai_runtime_pool_id",
-	"cluster":                 "cluster_id",
-	"endpoint":                "endpoint_id",
-	"warehouse":               "warehouse_id",
-	"dlt_pipeline":            "dlt_pipeline_id",
-	"metastore":               "metastore_id",
-}
-
 type Explorer interface {
 	ListSupportedResources(ctx context.Context) ([]domain.WorkspaceResource, error)
 }
@@ -44,7 +25,7 @@ func (w *workspaceExplorer) ListSupportedResources(
 	_ context.Context,
 ) ([]domain.WorkspaceResource, error) {
 	var resources []domain.WorkspaceResource
-	for resourceName, _ := range SupportedResources {
+	for resourceName, _ := range domain.SupportedResources {
 		resources = append(resources, domain.WorkspaceResource{WorkspaceName: w.ws.Name, ResourceName: resourceName})
 	}
 	return resources, nil
@@ -53,7 +34,7 @@ func (w *workspaceExplorer) ListSupportedResources(
 func validResourceTypes(types []string) []string {
 	var supportedTypes []string
 	for _, rt := range types {
-		if _, ok := SupportedResources[rt]; ok {
+		if _, ok := domain.SupportedResources[rt]; ok {
 			supportedTypes = append(supportedTypes, rt)
 		}
 	}

--- a/pkg/store/databrickssql/usage/store.go
+++ b/pkg/store/databrickssql/usage/store.go
@@ -91,7 +91,8 @@ func (u *usageStore) GetUsage(
 
 	query := `
 		SELECT
-			COALESCE(` + buildCoalesceList(domain.SupportedResourcesList, "_id") + `, 'default_storage') AS id,
+			record_id as id,
+			COALESCE(` + buildCoalesceList(domain.SupportedResourcesList, "_id") + `, 'default_storage') AS resource_id,
 			(
             	CASE
                 	` + buildResourceTypeCase(domain.SupportedResourcesList) + `
@@ -130,19 +131,20 @@ func (u *usageStore) GetUsage(
 	var records []store.UsageRecord
 	for rows.Next() {
 		var (
-			id, resourceType, usageType, unit, sku string
-			start, end                             time.Time
-			qty                                    float64
+			id, resourceID, resourceType, usageType, unit, sku string
+			start, end                                         time.Time
+			qty                                                float64
 		)
-		if err := rows.Scan(&id, &resourceType, &usageType, &start, &end, &qty, &unit, &sku); err != nil {
+		if err := rows.Scan(&id, &resourceID, &resourceType, &usageType, &start, &end, &qty, &unit, &sku); err != nil {
 			return nil, err
 		}
 
 		price := u.pricingStore.GetSkuPrice(ctx, sku)
 
 		records = append(records, store.UsageRecord{
-			ID:       id,
-			Resource: resourceType,
+			ID:           id,
+			ResourceID:   resourceID,
+			ResourceType: resourceType,
 			Metadata: map[string]string{
 				"usage_type":    usageType,
 				"resource_type": resourceType,
@@ -180,7 +182,8 @@ func (u *usageStore) GetResourcesUsage(
 
 	query := `
 		SELECT
-			COALESCE(` + buildCoalesceList(resources, "_id") + `, 'default_storage') AS id,
+			record_id as id,
+			COALESCE(` + buildCoalesceList(resources, "_id") + `, 'default_storage') AS resource_id,
 			(
 				CASE
 					` + buildResourceTypeCase(resources) + `
@@ -217,19 +220,20 @@ func (u *usageStore) GetResourcesUsage(
 	var records []store.UsageRecord
 	for rows.Next() {
 		var (
-			id, resourceType, usageType, unit, sku string
-			start, end                             time.Time
-			qty                                    float64
+			id, resourceID, resourceType, usageType, unit, sku string
+			start, end                                         time.Time
+			qty                                                float64
 		)
-		if err := rows.Scan(&id, &resourceType, &usageType, &start, &end, &qty, &unit, &sku); err != nil {
+		if err := rows.Scan(&id, &resourceID, &resourceType, &usageType, &start, &end, &qty, &unit, &sku); err != nil {
 			return nil, err
 		}
 
 		price := u.pricingStore.GetSkuPrice(ctx, sku)
 
 		records = append(records, store.UsageRecord{
-			ID:       id,
-			Resource: resourceType,
+			ID:           id,
+			ResourceID:   resourceID,
+			ResourceType: resourceType,
 			Metadata: map[string]string{
 				"usage_type":    usageType,
 				"resource_type": resourceType,

--- a/pkg/store/databrickssql/usage/store.go
+++ b/pkg/store/databrickssql/usage/store.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/de-tools/data-atlas/pkg/models/domain"
 	"github.com/de-tools/data-atlas/pkg/store/databrickssql/pricing"
 
 	"github.com/de-tools/data-atlas/pkg/models/store"
@@ -43,10 +44,10 @@ func (u *usageStore) GetUsageStats(ctx context.Context, startTime *time.Time) (*
 	logger := zerolog.Ctx(ctx)
 
 	query := `
-        SELECT 
+        SELECT
             COUNT(*) as total_records,
             MIN(usage_start_time) as earliest_record
-        FROM 
+        FROM
             system.billing.usage
         `
 
@@ -90,19 +91,25 @@ func (u *usageStore) GetUsage(
 
 	query := `
 		SELECT
-			record_id as id,
+			COALESCE(` + buildCoalesceList(domain.SupportedResourcesList, "_id") + `, 'default_storage') AS id,
+			(
+            	CASE
+                	` + buildResourceTypeCase(domain.SupportedResourcesList) + `
+                	ELSE 'api_operation'
+            	END
+        	) AS resource_type,
 			usage_type,
 			usage_start_time,
 			usage_end_time,
 			usage_quantity,
 			usage_unit,
 			sku_name
-		FROM 
+		FROM
 		    system.billing.usage
-		WHERE 
-		    usage_start_time >= ? AND usage_end_time < ?
-		ORDER BY 
-		    usage_start_time 
+		WHERE
+		    usage_start_time >= ? AND usage_start_time < ?
+		ORDER BY
+		    usage_start_time
 		DESC
 	`
 
@@ -123,20 +130,22 @@ func (u *usageStore) GetUsage(
 	var records []store.UsageRecord
 	for rows.Next() {
 		var (
-			id, usageType, unit, sku string
-			start, end               time.Time
-			qty                      float64
+			id, resourceType, usageType, unit, sku string
+			start, end                             time.Time
+			qty                                    float64
 		)
-		if err := rows.Scan(&id, &usageType, &start, &end, &qty, &unit, &sku); err != nil {
+		if err := rows.Scan(&id, &resourceType, &usageType, &start, &end, &qty, &unit, &sku); err != nil {
 			return nil, err
 		}
 
 		price := u.pricingStore.GetSkuPrice(ctx, sku)
 
 		records = append(records, store.UsageRecord{
-			ID: id,
+			ID:       id,
+			Resource: resourceType,
 			Metadata: map[string]string{
-				"usage_type": usageType,
+				"usage_type":    usageType,
+				"resource_type": resourceType,
 			},
 			StartTime: start,
 			EndTime:   end,
@@ -159,6 +168,10 @@ func (u *usageStore) GetResourcesUsage(
 ) ([]store.UsageRecord, error) {
 	logger := zerolog.Ctx(ctx)
 
+	if len(resources) == 0 {
+		return []store.UsageRecord{}, nil
+	}
+
 	var conditions []string
 	for _, resourceType := range resources {
 		idField := fmt.Sprintf("usage_metadata.%s_id", resourceType)
@@ -167,13 +180,14 @@ func (u *usageStore) GetResourcesUsage(
 
 	query := `
 		SELECT
-			COALESCE(` + buildCoalesceList(resources, "_id") + `) AS id,
+			COALESCE(` + buildCoalesceList(resources, "_id") + `, 'default_storage') AS id,
 			(
 				CASE
 					` + buildResourceTypeCase(resources) + `
-					ELSE 'unknown'
+					ELSE 'api_operation'
 				END
 			) AS resource_type,
+			usage_type,
 			usage_start_time,
 			usage_end_time,
 			usage_quantity,
@@ -203,19 +217,21 @@ func (u *usageStore) GetResourcesUsage(
 	var records []store.UsageRecord
 	for rows.Next() {
 		var (
-			id, resourceType, unit, sku string
-			start, end                  time.Time
-			qty                         float64
+			id, resourceType, usageType, unit, sku string
+			start, end                             time.Time
+			qty                                    float64
 		)
-		if err := rows.Scan(&id, &resourceType, &start, &end, &qty, &unit, &sku); err != nil {
+		if err := rows.Scan(&id, &resourceType, &usageType, &start, &end, &qty, &unit, &sku); err != nil {
 			return nil, err
 		}
 
 		price := u.pricingStore.GetSkuPrice(ctx, sku)
 
 		records = append(records, store.UsageRecord{
-			ID: id,
+			ID:       id,
+			Resource: resourceType,
 			Metadata: map[string]string{
+				"usage_type":    usageType,
 				"resource_type": resourceType,
 			},
 			StartTime: start,

--- a/pkg/store/duckdb/usage/store.go
+++ b/pkg/store/duckdb/usage/store.go
@@ -36,7 +36,7 @@ func (u *usageStore) Add(ctx context.Context, workspace string, records []store.
 	tx := duckdb.GetTransaction(ctx)
 	query := `
 		INSERT INTO usage_records (
-			id, workspace, resource, metadata, quantity, unit, 
+			id, workspace, resource, metadata, quantity, unit,
 			sku, rate, currency, start_time, end_time
 		) VALUES (
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
@@ -64,7 +64,7 @@ func (u *usageStore) Add(ctx context.Context, workspace string, records []store.
 		_, err = stmt.ExecContext(ctx,
 			record.ID,
 			workspace,
-			record.Resource,
+			record.ResourceType,
 			metadata,
 			record.Quantity,
 			record.Unit,

--- a/pkg/store/duckdb/usage/store_test.go
+++ b/pkg/store/duckdb/usage/store_test.go
@@ -47,8 +47,8 @@ func TestUsageStore_Add(t *testing.T) {
 		workspace := "test-workspace"
 		records := []store.UsageRecord{
 			{
-				ID:       "record1",
-				Resource: "compute",
+				ID:           "record1",
+				ResourceType: "compute",
 				Metadata: map[string]string{
 					"instance_type": "t2.micro",
 				},
@@ -61,8 +61,8 @@ func TestUsageStore_Add(t *testing.T) {
 				EndTime:   time.Date(2024, 1, 1, 1, 0, 0, 0, time.UTC),
 			},
 			{
-				ID:       "record2",
-				Resource: "storage",
+				ID:           "record2",
+				ResourceType: "storage",
 				Metadata: map[string]string{
 					"type": "ssd",
 				},
@@ -95,11 +95,11 @@ func TestUsageStore_Add(t *testing.T) {
 		workspace := "test-workspace"
 		records := []store.UsageRecord{
 			{
-				ID:        "duplicate",
-				Resource:  "compute",
-				Quantity:  1.0,
-				StartTime: time.Now(),
-				EndTime:   time.Now(),
+				ID:           "duplicate",
+				ResourceType: "compute",
+				Quantity:     1.0,
+				StartTime:    time.Now(),
+				EndTime:      time.Now(),
 			},
 		}
 


### PR DESCRIPTION
1. Make GetResourcesUsage and GetUsage behaviour unified, they both fetch ID, ResourceID and ResourceType
2. Add ResourceID (resource name) to UsageRecord model