### PR TITLE
Add DuckDB fetch methods and inject it into manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Build the project first.
 
 ## Using API server
 ### Run locally
-* Run server: `./cost -c  $HOME/.databrickscfg`
+* Run server: `./cost -c $HOME/.databrickscfg --sync`
 * Base URL: http://localhost:8080/api/v1
 * Date format in queries: DD-MM-YYYY (e.g., 02-01-2006)
 

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -21,6 +21,7 @@ import (
 )
 
 var cfgPath string
+var syncEnabled bool
 
 func main() {
 	var rootCmd = &cobra.Command{
@@ -34,6 +35,7 @@ func main() {
 
 	rootCmd.Flags().StringVarP(&cfgPath, "config", "c", defaultPath,
 		"Path to the .databrickscfg file (default is $HOME/.databrickscfg)")
+	rootCmd.Flags().BoolVar(&syncEnabled, "sync", false, "Start the syncing flow for workflows")
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
@@ -78,7 +80,7 @@ func runServer(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to create usage store: %w", err)
 	}
 	workflowCtrl := workflow.NewController(db, accountExplorer, workflowStore, usageStore)
-	err = workflowCtrl.Init(ctx)
+	err = workflowCtrl.Init(ctx, syncEnabled)
 	if err != nil {
 		return fmt.Errorf("failed to initialize workflow controller: %w", err)
 	}

--- a/pkg/handlers/workspace/handler.go
+++ b/pkg/handlers/workspace/handler.go
@@ -117,7 +117,7 @@ func (r *Router) GetResourceCost(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	costManager, err := r.explorer.GetWorkspaceCostManager(ctx, ws)
+	costManager, err := r.explorer.GetWorkspaceCostManagerCached(ctx, ws)
 	if err != nil {
 		handleError(ctx, w, http.StatusNotFound, err)
 		return
@@ -158,7 +158,7 @@ func (r *Router) GetWorkspaceResourcesCost(w http.ResponseWriter, req *http.Requ
 		return
 	}
 
-	costManager, err := r.explorer.GetWorkspaceCostManager(ctx, ws)
+	costManager, err := r.explorer.GetWorkspaceCostManagerCached(ctx, ws)
 	if err != nil {
 		handleError(ctx, w, http.StatusNotFound, err)
 		return

--- a/pkg/handlers/workspace/handler_test.go
+++ b/pkg/handlers/workspace/handler_test.go
@@ -49,6 +49,17 @@ func (m *mockAccountExplorer) GetWorkspaceCostManager(
 	return args.Get(0).(workspace.CostManager), args.Error(1)
 }
 
+func (m *mockAccountExplorer) GetWorkspaceSourceCostManager(
+	ctx context.Context,
+	ws domain.Workspace,
+) (workspace.CostManager, error) {
+	args := m.Called(ctx, ws)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(workspace.CostManager), args.Error(1)
+}
+
 type mockWorkspaceExplorer struct {
 	mock.Mock
 }

--- a/pkg/handlers/workspace/handler_test.go
+++ b/pkg/handlers/workspace/handler_test.go
@@ -38,7 +38,7 @@ func (m *mockAccountExplorer) GetWorkspaceExplorer(
 	return args.Get(0).(workspace.Explorer), args.Error(1)
 }
 
-func (m *mockAccountExplorer) GetWorkspaceCostManager(
+func (m *mockAccountExplorer) GetWorkspaceCostManagerCached(
 	ctx context.Context,
 	ws domain.Workspace,
 ) (workspace.CostManager, error) {
@@ -49,7 +49,7 @@ func (m *mockAccountExplorer) GetWorkspaceCostManager(
 	return args.Get(0).(workspace.CostManager), args.Error(1)
 }
 
-func (m *mockAccountExplorer) GetWorkspaceSourceCostManager(
+func (m *mockAccountExplorer) GetWorkspaceCostManagerRemote(
 	ctx context.Context,
 	ws domain.Workspace,
 ) (workspace.CostManager, error) {
@@ -239,7 +239,7 @@ func TestGetResourceCost(t *testing.T) {
 				"to":   "13-07-2025",
 			},
 			setupMock: func(me *mockAccountExplorer, cm *mockWorkspaceCostManager) {
-				me.On("GetWorkspaceCostManager", mock.Anything, domain.Workspace{Name: "test-workspace"}).
+				me.On("GetWorkspaceCostManagerCached", mock.Anything, domain.Workspace{Name: "test-workspace"}).
 					Return(cm, nil)
 
 				cm.On("GetResourcesCost",
@@ -344,7 +344,7 @@ func TestGetResourceCost(t *testing.T) {
 				"to":   "13-07-2025",
 			},
 			setupMock: func(me *mockAccountExplorer, cm *mockWorkspaceCostManager) {
-				me.On("GetWorkspaceCostManager", mock.Anything, domain.Workspace{Name: "test-workspace"}).
+				me.On("GetWorkspaceCostManagerCached", mock.Anything, domain.Workspace{Name: "test-workspace"}).
 					Return(nil, fmt.Errorf("workspace not found"))
 			},
 			expectedStatus: http.StatusNotFound,

--- a/pkg/services/account/explorer.go
+++ b/pkg/services/account/explorer.go
@@ -10,7 +10,9 @@ import (
 	"strings"
 
 	"github.com/de-tools/data-atlas/pkg/store/databrickssql/pricing"
-	"github.com/de-tools/data-atlas/pkg/store/databrickssql/usage"
+	dbusage "github.com/de-tools/data-atlas/pkg/store/databrickssql/usage"
+	duckdbstore "github.com/de-tools/data-atlas/pkg/store/duckdb"
+	duckdbusage "github.com/de-tools/data-atlas/pkg/store/duckdb/usage"
 
 	"github.com/databricks/databricks-sdk-go/config"
 	_ "github.com/databricks/databricks-sql-go" // Required for databricks sql
@@ -23,7 +25,10 @@ import (
 type Explorer interface {
 	ListWorkspaces(ctx context.Context) ([]domain.Workspace, error)
 	GetWorkspaceExplorer(ctx context.Context, ws domain.Workspace) (workspace.Explorer, error)
+	// GetWorkspaceCostManager returns a DuckDB-backed cost manager for API reads
 	GetWorkspaceCostManager(ctx context.Context, ws domain.Workspace) (workspace.CostManager, error)
+	// GetWorkspaceSourceCostManager returns a Databricks-backed cost manager for ingestion
+	GetWorkspaceSourceCostManager(ctx context.Context, ws domain.Workspace) (workspace.CostManager, error)
 }
 
 type accountExplorer struct {
@@ -56,6 +61,22 @@ func (a *accountExplorer) GetWorkspaceExplorer(ctx context.Context, ws domain.Wo
 }
 
 func (a *accountExplorer) GetWorkspaceCostManager(
+	ctx context.Context,
+	ws domain.Workspace,
+) (workspace.CostManager, error) {
+	// DuckDB-backed CostManager for API read paths
+	db, err := duckdbstore.NewDB(duckdbstore.Settings{DbPath: "data-atlas.db"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create DuckDB instance: %w", err)
+	}
+	usageStore, err := duckdbusage.NewWorkspaceStore(db, ws.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create DuckDB usage store: %w", err)
+	}
+	return workspace.NewCostManager(usageStore), nil
+}
+
+func (a *accountExplorer) GetWorkspaceSourceCostManager(
 	ctx context.Context,
 	ws domain.Workspace,
 ) (workspace.CostManager, error) {
@@ -93,9 +114,8 @@ func (a *accountExplorer) GetWorkspaceCostManager(
 		log.Fatalf("failed to connect to Databricks: %v", err)
 	}
 
-	usageStore := usage.NewStore(db, pricing.NewStore())
+	usageStore := dbusage.NewStore(db, pricing.NewStore())
 	costManager := workspace.NewCostManager(usageStore)
-
 	return costManager, nil
 }
 

--- a/pkg/services/account/workspace/cost.go
+++ b/pkg/services/account/workspace/cost.go
@@ -22,8 +22,6 @@ type CostManager interface {
 
 // UsageStore is the minimal interface required by CostManager for reading usage
 // Implemented by both Databricks SQL and DuckDB usage stores
-// Note: It excludes mutating methods like Add
-// so we can plug different storage backends seamlessly.
 type UsageStore interface {
 	GetResourcesUsage(ctx context.Context, resources []string, startTime, endTime time.Time) ([]store.UsageRecord, error)
 	GetUsage(ctx context.Context, startTime, endTime time.Time) ([]store.UsageRecord, error)

--- a/pkg/services/workflow/controller.go
+++ b/pkg/services/workflow/controller.go
@@ -98,7 +98,7 @@ func (ctrl *DefaultController) startWorkflow(ctx context.Context, wf *store.Work
 
 	ctx, cancel := context.WithCancel(ctx)
 
-	costExplorer, err := ctrl.explorer.GetWorkspaceSourceCostManager(ctx, domain.Workspace{Name: wf.Workspace})
+	costExplorer, err := ctrl.explorer.GetWorkspaceCostManagerRemote(ctx, domain.Workspace{Name: wf.Workspace})
 	if err != nil {
 		cancel()
 		return err

--- a/pkg/services/workflow/controller.go
+++ b/pkg/services/workflow/controller.go
@@ -53,14 +53,16 @@ func NewController(
 	return ctrl
 }
 
-func (ctrl *DefaultController) Init(ctx context.Context) error {
+func (ctrl *DefaultController) Init(ctx context.Context, syncEnabled bool) error {
 	workflows, err := ctrl.workflowStore.ListWorkflows(ctx, []string{})
 	if err != nil {
 		return err
 	}
 
-	for _, wf := range workflows {
-		ctrl.startWorkflow(ctx, wf)
+	if syncEnabled {
+		for _, wf := range workflows {
+			ctrl.startWorkflow(ctx, wf)
+		}
 	}
 
 	return nil

--- a/pkg/services/workflow/controller.go
+++ b/pkg/services/workflow/controller.go
@@ -98,7 +98,7 @@ func (ctrl *DefaultController) startWorkflow(ctx context.Context, wf *store.Work
 
 	ctx, cancel := context.WithCancel(ctx)
 
-	costExplorer, err := ctrl.explorer.GetWorkspaceCostManager(ctx, domain.Workspace{Name: wf.Workspace})
+	costExplorer, err := ctrl.explorer.GetWorkspaceSourceCostManager(ctx, domain.Workspace{Name: wf.Workspace})
 	if err != nil {
 		cancel()
 		return err

--- a/pkg/services/workflow/runner.go
+++ b/pkg/services/workflow/runner.go
@@ -54,7 +54,7 @@ func NewRunner(
 		done:          make(chan struct{}),
 		progress:      make(chan RunnerProgress, 100),
 		config: RunnerConfig{
-			BatchInterval: 7 * 24 * time.Hour,
+			BatchInterval: 700 * 24 * time.Hour,
 			SleepInterval: 10 * time.Second,
 		},
 	}

--- a/pkg/services/workflow/runner.go
+++ b/pkg/services/workflow/runner.go
@@ -55,7 +55,7 @@ func NewRunner(
 		progress:      make(chan RunnerProgress, 100),
 		config: RunnerConfig{
 			BatchInterval: 365 * 24 * time.Hour,
-			SleepInterval: 10 * time.Second,
+			SleepInterval: 1 * time.Minute,
 		},
 	}
 }

--- a/pkg/services/workflow/runner.go
+++ b/pkg/services/workflow/runner.go
@@ -54,7 +54,7 @@ func NewRunner(
 		done:          make(chan struct{}),
 		progress:      make(chan RunnerProgress, 100),
 		config: RunnerConfig{
-			BatchInterval: 700 * 24 * time.Hour,
+			BatchInterval: 365 * 24 * time.Hour,
 			SleepInterval: 10 * time.Second,
 		},
 	}

--- a/pkg/store/duckdb/storage.go
+++ b/pkg/store/duckdb/storage.go
@@ -21,7 +21,8 @@ const UsageTableSchema = `
 	CREATE TABLE IF NOT EXISTS usage_records (
 		id VARCHAR NOT NULL,
 		workspace VARCHAR NOT NULL,
-		resource VARCHAR,
+		resource_id VARCHAR,
+		resource_type VARCHAR,
 		metadata JSON,
 		quantity DOUBLE,
 		unit VARCHAR,

--- a/pkg/store/duckdb/usage/store.go
+++ b/pkg/store/duckdb/usage/store.go
@@ -142,7 +142,7 @@ func (u *usageStore) GetResourcesUsage(ctx context.Context, resources []string, 
 	for range resources {
 		placeholders = append(placeholders, "?")
 	}
-	// Adjust args to match order: workspace, start, end, resources...
+
 	args = append([]interface{}{u.workspace, startTime, endTime}, toInterfaceSlice(resources)...)
 
 	query := fmt.Sprintf(`

--- a/pkg/store/duckdb/usage/store.go
+++ b/pkg/store/duckdb/usage/store.go
@@ -5,18 +5,26 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/de-tools/data-atlas/pkg/store/duckdb"
 
 	"github.com/de-tools/data-atlas/pkg/models/store"
 )
 
+// Store supports both ingestion (Add) and read (Get*) operations for usage records in DuckDB
+// For read operations, bind the store to a specific workspace via NewWorkspaceStore
+// Note: Add still accepts workspace parameter to minimize changes in workflow runner.
 type Store interface {
 	Add(ctx context.Context, workspace string, records []store.UsageRecord) error
+	GetResourcesUsage(ctx context.Context, resources []string, startTime, endTime time.Time) ([]store.UsageRecord, error)
+	GetUsage(ctx context.Context, startTime, endTime time.Time) ([]store.UsageRecord, error)
+	GetUsageStats(ctx context.Context, startTime *time.Time) (*store.UsageStats, error)
 }
 
 type usageStore struct {
-	db *sql.DB
+	db        *sql.DB
+	workspace string // optional; required for read methods
 }
 
 func NewStore(db *sql.DB) (Store, error) {
@@ -25,6 +33,20 @@ func NewStore(db *sql.DB) (Store, error) {
 	}
 	return &usageStore{
 		db: db,
+	}, nil
+}
+
+// NewWorkspaceStore returns a Store bound to a specific workspace for read operations
+func NewWorkspaceStore(db *sql.DB, workspace string) (Store, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database connection is nil")
+	}
+	if workspace == "" {
+		return nil, fmt.Errorf("workspace is required for read store")
+	}
+	return &usageStore{
+		db:        db,
+		workspace: workspace,
 	}, nil
 }
 
@@ -81,4 +103,135 @@ func (u *usageStore) Add(ctx context.Context, workspace string, records []store.
 	}
 
 	return nil
+}
+
+func (u *usageStore) ensureWorkspace() error {
+	if u.workspace == "" {
+		return fmt.Errorf("read operation requires workspace-bound store; use NewWorkspaceStore")
+	}
+	return nil
+}
+
+func (u *usageStore) GetUsage(ctx context.Context, startTime, endTime time.Time) ([]store.UsageRecord, error) {
+	if err := u.ensureWorkspace(); err != nil {
+		return nil, err
+	}
+	query := `
+		SELECT id, resource, metadata, quantity, unit, sku, rate, currency, start_time, end_time
+		FROM usage_records
+		WHERE workspace = ? AND start_time >= ? AND start_time < ?
+		ORDER BY start_time DESC
+	`
+	rows, err := u.db.QueryContext(ctx, query, u.workspace, startTime, endTime)
+	if err != nil {
+		return nil, fmt.Errorf("query usage: %w", err)
+	}
+	defer rows.Close()
+	return scanUsageRows(rows)
+}
+
+func (u *usageStore) GetResourcesUsage(ctx context.Context, resources []string, startTime, endTime time.Time) ([]store.UsageRecord, error) {
+	if err := u.ensureWorkspace(); err != nil {
+		return nil, err
+	}
+	if len(resources) == 0 {
+		return []store.UsageRecord{}, nil
+	}
+	// Build placeholders for IN clause
+	placeholders := make([]string, 0, len(resources))
+	args := make([]interface{}, 0, 2+len(resources))
+	args = append(args, u.workspace, startTime, endTime)
+	for range resources {
+		placeholders = append(placeholders, "?")
+	}
+	// Adjust args to match order: workspace, start, end, resources...
+	args = append([]interface{}{u.workspace, startTime, endTime}, toInterfaceSlice(resources)...)
+
+	query := fmt.Sprintf(`
+		SELECT id, resource, metadata, quantity, unit, sku, rate, currency, start_time, end_time
+		FROM usage_records
+		WHERE workspace = ? AND start_time >= ? AND start_time < ? AND resource IN (%s)
+		ORDER BY start_time DESC
+	`, join(placeholders, ","))
+
+	rows, err := u.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query usage by resources: %w", err)
+	}
+	defer rows.Close()
+	return scanUsageRows(rows)
+}
+
+func (u *usageStore) GetUsageStats(ctx context.Context, startTime *time.Time) (*store.UsageStats, error) {
+	if err := u.ensureWorkspace(); err != nil {
+		return nil, err
+	}
+	query := `SELECT COUNT(*) as total_records, MIN(start_time) as earliest_record FROM usage_records WHERE workspace = ?`
+	args := []interface{}{u.workspace}
+	if startTime != nil {
+		query += " AND start_time > ?"
+		args = append(args, *startTime)
+	}
+	var total int64
+	var earliest sql.NullTime
+	if err := u.db.QueryRowContext(ctx, query, args...).Scan(&total, &earliest); err != nil {
+		return nil, fmt.Errorf("get usage stats: %w", err)
+	}
+	var first *time.Time
+	if earliest.Valid {
+		t := earliest.Time
+		first = &t
+	}
+	return &store.UsageStats{RecordsCount: total, FirstRecordTime: first}, nil
+}
+
+func scanUsageRows(rows *sql.Rows) ([]store.UsageRecord, error) {
+	records := make([]store.UsageRecord, 0)
+	for rows.Next() {
+		var (
+			id, resource, unit, sku, currency string
+			metadataRaw                       []byte
+			qty, rate                         float64
+			start, end                        time.Time
+		)
+		if err := rows.Scan(&id, &resource, &metadataRaw, &qty, &unit, &sku, &rate, &currency, &start, &end); err != nil {
+			return nil, err
+		}
+		md := map[string]string{}
+		if len(metadataRaw) > 0 {
+			_ = json.Unmarshal(metadataRaw, &md)
+		}
+		records = append(records, store.UsageRecord{
+			ID:        id,
+			Resource:  resource,
+			Metadata:  md,
+			Quantity:  qty,
+			Unit:      unit,
+			SKU:       sku,
+			Rate:      rate,
+			Currency:  currency,
+			StartTime: start,
+			EndTime:   end,
+		})
+	}
+	return records, nil
+}
+
+func toInterfaceSlice(ss []string) []interface{} {
+	res := make([]interface{}, len(ss))
+	for i, s := range ss {
+		res[i] = s
+	}
+	return res
+}
+
+func join(items []string, sep string) string {
+	if len(items) == 0 {
+		return ""
+	}
+	out := items[0]
+	for i := 1; i < len(items); i++ {
+		out += sep + items[i]
+	}
+	return out
 }


### PR DESCRIPTION
1. Add fetching methods to ducks db store
2. Introduce `UsageStore` interface that will be implemented by ducks db and databricks stores
3. Introduce a --sync flag, existing workflows sync will be started only if it is passed. Calling a /sync API will start the workflow regardless of the flag 
4. Now all controllers use ducks db store fetch methods. Workflows populate ducks db store by fetching data from databrciks