### PR TITLE
Add dlt pipeline audit endpoint and service

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Build the project first.
 * List workspaces - `curl -s http://localhost:8080/api/v1/workspaces | jq`
 * List resources in a workspace -
 `curl -s http://localhost:8080/api/v1/{workspace}/resources | jq`
-* Resource cost for a single resource type - `curl -s http://localhost:8080/api/v1/workspaces/{workspace}/resources/{resource}/cost?from={from}&to={to} | jq`
-* Resource cost for multiple resource types - `curl -s http://localhost:8080/api/v1/workspaces/{workspace}/resources/cost?resource={resource_1}&resource={resource_2}&from={from}&to={to} | jq`
+* Resource cost for a single resource type - `curl -s http://localhost:8080/api/v1/workspaces/{workspace}/resources/{resource}/cost?from={from}\&to={to} | jq`
+* Resource cost for multiple resource types - `curl -s http://localhost:8080/api/v1/workspaces/{workspace}/resources/cost?resource={resource_1}&resource={resource_2}\&from={from}\&to={to} | jq`
 * Start usage sync workflow - `curl -s -X POST http://localhost:8080/api/v1/workspaces/{workspace}/sync`
+* Audit DTL pipelines - `curl -s http://localhost:8080/api/v1/workspaces/{workspace}/resources/dlt_pipeline/audit?from={from}\&to={to} | jq`

--- a/pkg/adapters/audit.go
+++ b/pkg/adapters/audit.go
@@ -1,0 +1,56 @@
+package adapters
+
+import (
+	"github.com/de-tools/data-atlas/pkg/models/api"
+	"github.com/de-tools/data-atlas/pkg/models/domain"
+)
+
+func MapSeverityDomainToApi(s domain.Severity) api.Severity {
+	switch s {
+	case domain.SeverityLow:
+		return api.SeverityLow
+	case domain.SeverityMedium:
+		return api.SeverityMedium
+	case domain.SeverityHigh:
+		return api.SeverityHigh
+	default:
+		return api.SeverityLow
+	}
+}
+
+func MapTimePeriodDomainToApi(p domain.TimePeriod) api.TimePeriod {
+	return api.TimePeriod{
+		Start:    p.Start,
+		End:      p.End,
+		Duration: p.Duration,
+	}
+}
+
+func MapAuditFindingDomainToApi(f domain.AuditFinding) api.AuditFinding {
+	return api.AuditFinding{
+		Id:             f.Id,
+		Resource:       MapResourceDefinitionDomainToApi(f.Resource),
+		Issue:          f.Issue,
+		Description:    f.Description,
+		Recommendation: f.Recommendation,
+		Severity:       MapSeverityDomainToApi(f.Severity),
+	}
+}
+
+func MapAuditReportDomainToApi(r domain.AuditReport) api.AuditReport {
+	res := api.AuditReport{
+		Workspace:    r.Workspace,
+		ResourceType: r.ResourceType,
+		Period:       MapTimePeriodDomainToApi(r.Period),
+		Summary:      map[string]any{},
+		Findings:     make([]api.AuditFinding, 0, len(r.Findings)),
+	}
+	// copy summary as-is
+	for k, v := range r.Summary {
+		res.Summary[k] = v
+	}
+	for _, f := range r.Findings {
+		res.Findings = append(res.Findings, MapAuditFindingDomainToApi(f))
+	}
+	return res
+}

--- a/pkg/handlers/workspace/handler.go
+++ b/pkg/handlers/workspace/handler.go
@@ -247,7 +247,13 @@ func (r *Router) GetDLTAudit(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	report, err := workspace.GetDLTAudit(ctx, ws, startTime, endTime, costManager)
+	// For now construct audit settings here; later can be provided via DI
+	settings := workspace.DLTAuditSettings{
+		MaintenanceRatioThreshold:  0.3,
+		MinMaintenanceEvents:       3,
+		LongRunAvgSecondsThreshold: 2 * 3600,
+	}
+	report, err := workspace.GetDLTAudit(ctx, ws, startTime, endTime, costManager, settings)
 	if err != nil {
 		handleError(ctx, w, http.StatusInternalServerError, err)
 		return

--- a/pkg/models/api/audit.go
+++ b/pkg/models/api/audit.go
@@ -1,0 +1,34 @@
+package api
+
+import "time"
+
+type Severity string
+
+const (
+	SeverityLow    Severity = "low"
+	SeverityMedium Severity = "medium"
+	SeverityHigh   Severity = "high"
+)
+
+type AuditFinding struct {
+	Id             string      `json:"id"`
+	Resource       ResourceDef `json:"resource"`
+	Issue          string      `json:"issue"`
+	Description    string      `json:"description"`
+	Recommendation string      `json:"recommendation"`
+	Severity       Severity    `json:"severity"`
+}
+
+type TimePeriod struct {
+	Start    time.Time `json:"start"`
+	End      time.Time `json:"end"`
+	Duration int       `json:"duration_days"`
+}
+
+type AuditReport struct {
+	Workspace    string                 `json:"workspace"`
+	ResourceType string                 `json:"resource_type"`
+	Period       TimePeriod             `json:"period"`
+	Summary      map[string]interface{} `json:"summary"`
+	Findings     []AuditFinding         `json:"findings"`
+}

--- a/pkg/services/account/workspace/audit.go
+++ b/pkg/services/account/workspace/audit.go
@@ -1,0 +1,133 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/de-tools/data-atlas/pkg/models/domain"
+)
+
+// GetDLTAudit computes DLT pipelines audit for a workspace over the period.
+func GetDLTAudit(
+	ctx context.Context,
+	ws domain.Workspace,
+	startTime, endTime time.Time,
+	costManager CostManager,
+) (domain.AuditReport, error) {
+	// Collect DLT-related usage
+	resources := domain.WorkspaceResources{WorkspaceName: ws.Name, Resources: []string{"dlt_pipeline", "dlt_update", "dlt_maintenance"}}
+	records, err := costManager.GetResourcesCost(ctx, resources, startTime, endTime)
+	if err != nil {
+		return domain.AuditReport{}, err
+	}
+
+	// Aggregate per pipeline
+	type agg struct {
+		totalCost        float64
+		totalUsage       float64
+		updatesCount     int
+		maintenanceCount int
+		totalDurationSec float64
+		maxDurationSec   float64
+		currency         string
+	}
+	pipelines := map[string]*agg{}
+
+	for _, rec := range records {
+		id := rec.Resource.Name
+		if _, ok := pipelines[id]; !ok {
+			pipelines[id] = &agg{}
+		}
+		a := pipelines[id]
+		for _, c := range rec.Costs {
+			a.totalCost += c.TotalAmount
+			a.totalUsage += c.Value
+			if a.currency == "" {
+				a.currency = c.Currency
+			}
+		}
+		dur := rec.EndTime.Sub(rec.StartTime).Seconds()
+		a.totalDurationSec += dur
+		if dur > a.maxDurationSec {
+			a.maxDurationSec = dur
+		}
+		rt := rec.Resource.Service
+		if rt == "dlt_update" {
+			a.updatesCount++
+		}
+		if rt == "dlt_maintenance" {
+			a.maintenanceCount++
+		}
+	}
+
+	report := domain.AuditReport{
+		Workspace:    ws.Name,
+		ResourceType: "dlt_pipeline",
+		Period: domain.TimePeriod{
+			Start:    startTime,
+			End:      endTime,
+			Duration: int(endTime.Sub(startTime).Hours() / 24),
+		},
+		Summary:  map[string]any{},
+		Findings: []domain.AuditFinding{},
+	}
+
+	if len(records) == 0 {
+		report.Summary["no_activity"] = "No DLT usage records found in the selected period"
+		report.Findings = append(report.Findings, domain.AuditFinding{
+			Id:             "no_activity",
+			Resource:       domain.ResourceDef{Platform: "Databricks", Service: "dlt_pipeline", Name: "workspace"},
+			Issue:          "no_activity",
+			Description:    "No DLT pipeline activity detected in the selected time window.",
+			Recommendation: "Verify schedules/triggers and pipeline health. Consider reducing provisioned resources if unused.",
+			Severity:       domain.SeverityMedium,
+		})
+		return report, nil
+	}
+
+	var totalPipelines, highMaintenance, longRuns int
+	for pid, a := range pipelines {
+		totalPipelines++
+		maintenanceRatio := 0.0
+		totalEvents := a.updatesCount + a.maintenanceCount
+		if totalEvents > 0 {
+			maintenanceRatio = float64(a.maintenanceCount) / float64(totalEvents)
+		}
+		avgRunSec := 0.0
+		runEvents := a.updatesCount
+		if runEvents > 0 {
+			avgRunSec = a.totalDurationSec / float64(runEvents)
+		}
+
+		if maintenanceRatio > 0.3 && a.maintenanceCount >= 3 {
+			highMaintenance++
+			report.Findings = append(report.Findings, domain.AuditFinding{
+				Id:             fmt.Sprintf("%s_high_maintenance_overhead", pid),
+				Resource:       domain.ResourceDef{Platform: "Databricks", Service: "dlt_pipeline", Name: pid},
+				Issue:          "maintenance_overhead",
+				Description:    fmt.Sprintf("Maintenance events constitute %.0f%% of pipeline activity.", maintenanceRatio*100),
+				Recommendation: "Reduce pipeline maintenance frequency, consolidate tasks, or review autoscaling/pool warmups.",
+				Severity:       domain.SeverityMedium,
+			})
+		}
+
+		if avgRunSec > 2*3600 {
+			longRuns++
+			report.Findings = append(report.Findings, domain.AuditFinding{
+				Id:             fmt.Sprintf("%s_long_running_updates", pid),
+				Resource:       domain.ResourceDef{Platform: "Databricks", Service: "dlt_pipeline", Name: pid},
+				Issue:          "long_running_updates",
+				Description:    fmt.Sprintf("Average update duration is %.1f hours (max %.1f h).", avgRunSec/3600, a.maxDurationSec/3600),
+				Recommendation: "Consider incremental model optimization, Z-ordering, optimized autoscaling, and proper cluster sizing.",
+				Severity:       domain.SeverityMedium,
+			})
+		}
+	}
+
+	report.Summary["pipelines_evaluated"] = totalPipelines
+	report.Summary["pipelines_with_high_maintenance_overhead"] = highMaintenance
+	report.Summary["pipelines_with_long_running_updates"] = longRuns
+
+	return report, nil
+}

--- a/pkg/services/account/workspace/audit_test.go
+++ b/pkg/services/account/workspace/audit_test.go
@@ -41,7 +41,8 @@ func TestGetDLTAudit_NoRecords(t *testing.T) {
 	cm.On("GetResourcesCost", mock.Anything, domain.WorkspaceResources{WorkspaceName: ws.Name, Resources: []string{"dlt_pipeline", "dlt_update", "dlt_maintenance"}}, start, end).
 		Return([]domain.ResourceCost{}, nil)
 
-	report, err := GetDLTAudit(ctx, ws, start, end, cm)
+	settings := DLTAuditSettings{MaintenanceRatioThreshold: 0.3, MinMaintenanceEvents: 3, LongRunAvgSecondsThreshold: 2 * 3600}
+	report, err := GetDLTAudit(ctx, ws, start, end, cm, settings)
 	assert.NoError(t, err)
 	assert.Equal(t, ws.Name, report.Workspace)
 	assert.Equal(t, "dlt_pipeline", report.ResourceType)
@@ -109,7 +110,8 @@ func TestGetDLTAudit_MixedPipelines_FindingsAndSummary(t *testing.T) {
 	cm.On("GetResourcesCost", mock.Anything, domain.WorkspaceResources{WorkspaceName: ws.Name, Resources: []string{"dlt_pipeline", "dlt_update", "dlt_maintenance"}}, start, end).
 		Return(records, nil)
 
-	report, err := GetDLTAudit(ctx, ws, start, end, cm)
+	settings := DLTAuditSettings{MaintenanceRatioThreshold: 0.3, MinMaintenanceEvents: 3, LongRunAvgSecondsThreshold: 2 * 3600}
+	report, err := GetDLTAudit(ctx, ws, start, end, cm, settings)
 	assert.NoError(t, err)
 
 	// Summary checks
@@ -153,7 +155,8 @@ func TestGetDLTAudit_CostManagerError(t *testing.T) {
 	cm.On("GetResourcesCost", mock.Anything, domain.WorkspaceResources{WorkspaceName: ws.Name, Resources: []string{"dlt_pipeline", "dlt_update", "dlt_maintenance"}}, start, end).
 		Return(nil, errExpected)
 
-	_, err := GetDLTAudit(ctx, ws, start, end, cm)
+	settings := DLTAuditSettings{MaintenanceRatioThreshold: 0.3, MinMaintenanceEvents: 3, LongRunAvgSecondsThreshold: 2 * 3600}
+	_, err := GetDLTAudit(ctx, ws, start, end, cm, settings)
 	assert.ErrorIs(t, err, errExpected)
 	cm.AssertExpectations(t)
 }

--- a/pkg/services/account/workspace/audit_test.go
+++ b/pkg/services/account/workspace/audit_test.go
@@ -1,0 +1,159 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/de-tools/data-atlas/pkg/models/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockCostManager struct{ mock.Mock }
+
+func (m *mockCostManager) GetResourcesCost(
+	ctx context.Context,
+	res domain.WorkspaceResources,
+	startTime, endTime time.Time,
+) ([]domain.ResourceCost, error) {
+	args := m.Called(ctx, res, startTime, endTime)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]domain.ResourceCost), args.Error(1)
+}
+func (m *mockCostManager) GetUsageStats(ctx context.Context, startTime *time.Time) (*domain.UsageStats, error) {
+	return nil, nil
+}
+func (m *mockCostManager) GetUsage(ctx context.Context, startTime, endTime time.Time) ([]domain.ResourceCost, error) {
+	return nil, nil
+}
+
+func TestGetDLTAudit_NoRecords(t *testing.T) {
+	ctx := context.Background()
+	ws := domain.Workspace{Name: "ws1"}
+	start := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 9, 8, 0, 0, 0, 0, time.UTC)
+
+	cm := new(mockCostManager)
+	cm.On("GetResourcesCost", mock.Anything, domain.WorkspaceResources{WorkspaceName: ws.Name, Resources: []string{"dlt_pipeline", "dlt_update", "dlt_maintenance"}}, start, end).
+		Return([]domain.ResourceCost{}, nil)
+
+	report, err := GetDLTAudit(ctx, ws, start, end, cm)
+	assert.NoError(t, err)
+	assert.Equal(t, ws.Name, report.Workspace)
+	assert.Equal(t, "dlt_pipeline", report.ResourceType)
+	assert.Equal(t, 1, len(report.Findings))
+	assert.Equal(t, "no_activity", report.Findings[0].Issue)
+	assert.Equal(t, domain.SeverityMedium, report.Findings[0].Severity)
+	assert.Equal(t, "Databricks", report.Findings[0].Resource.Platform)
+	assert.Equal(t, "dlt_pipeline", report.Findings[0].Resource.Service)
+	assert.Equal(t, "workspace", report.Findings[0].Resource.Name)
+	assert.Equal(t, "No DLT usage records found in the selected period", report.Summary["no_activity"])
+	cm.AssertExpectations(t)
+}
+
+func TestGetDLTAudit_MixedPipelines_FindingsAndSummary(t *testing.T) {
+	ctx := context.Background()
+	ws := domain.Workspace{Name: "ws1"}
+	start := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 9, 8, 0, 0, 0, 0, time.UTC)
+
+	pidA := "pipeline-a"
+	pidB := "pipeline-b"
+
+	records := []domain.ResourceCost{
+		// Pipeline A: 2 updates (1h each), 3 maintenance (0.5h each) => total 3.5h, avgRun = 3.5h/2 = 1.75h (<2h)
+		{
+			StartTime: start,
+			EndTime:   start.Add(1 * time.Hour),
+			Resource:  domain.ResourceDef{Platform: "Databricks", Service: "dlt_update", Name: pidA},
+			Costs:     []domain.CostComponent{{Currency: "USD", TotalAmount: 1, Value: 1}},
+		},
+		{
+			StartTime: start.Add(2 * time.Hour),
+			EndTime:   start.Add(3 * time.Hour),
+			Resource:  domain.ResourceDef{Platform: "Databricks", Service: "dlt_update", Name: pidA},
+			Costs:     []domain.CostComponent{{Currency: "USD", TotalAmount: 1, Value: 1}},
+		},
+		{
+			StartTime: start.Add(4 * time.Hour),
+			EndTime:   start.Add(4*time.Hour + 30*time.Minute),
+			Resource:  domain.ResourceDef{Platform: "Databricks", Service: "dlt_maintenance", Name: pidA},
+			Costs:     []domain.CostComponent{{Currency: "USD", TotalAmount: 0.5, Value: 0.5}},
+		},
+		{
+			StartTime: start.Add(5 * time.Hour),
+			EndTime:   start.Add(5*time.Hour + 30*time.Minute),
+			Resource:  domain.ResourceDef{Platform: "Databricks", Service: "dlt_maintenance", Name: pidA},
+			Costs:     []domain.CostComponent{{Currency: "USD", TotalAmount: 0.5, Value: 0.5}},
+		},
+		{
+			StartTime: start.Add(6 * time.Hour),
+			EndTime:   start.Add(6*time.Hour + 30*time.Minute),
+			Resource:  domain.ResourceDef{Platform: "Databricks", Service: "dlt_maintenance", Name: pidA},
+			Costs:     []domain.CostComponent{{Currency: "USD", TotalAmount: 0.5, Value: 0.5}},
+		},
+		// Pipeline B: 1 update of 3h (max 3h) => avgRun 3h > 2h, long running
+		{
+			StartTime: start.Add(24 * time.Hour),
+			EndTime:   start.Add(27 * time.Hour),
+			Resource:  domain.ResourceDef{Platform: "Databricks", Service: "dlt_update", Name: pidB},
+			Costs:     []domain.CostComponent{{Currency: "USD", TotalAmount: 3, Value: 3}},
+		},
+	}
+
+	cm := new(mockCostManager)
+	cm.On("GetResourcesCost", mock.Anything, domain.WorkspaceResources{WorkspaceName: ws.Name, Resources: []string{"dlt_pipeline", "dlt_update", "dlt_maintenance"}}, start, end).
+		Return(records, nil)
+
+	report, err := GetDLTAudit(ctx, ws, start, end, cm)
+	assert.NoError(t, err)
+
+	// Summary checks
+	assert.Equal(t, 2, report.Summary["pipelines_evaluated"])
+	assert.Equal(t, 1, report.Summary["pipelines_with_high_maintenance_overhead"])
+	assert.Equal(t, 1, report.Summary["pipelines_with_long_running_updates"])
+
+	// Findings checks: should contain one for pidA maintenance_overhead and one for pidB long_running_updates
+	issuesByPipeline := map[string]map[string]bool{}
+	for _, f := range report.Findings {
+		if _, ok := issuesByPipeline[f.Resource.Name]; !ok {
+			issuesByPipeline[f.Resource.Name] = map[string]bool{}
+		}
+		issuesByPipeline[f.Resource.Name][f.Issue] = true
+	}
+
+	assert.True(t, issuesByPipeline[pidA]["maintenance_overhead"], "expected maintenance_overhead for pipeline A")
+	assert.True(t, issuesByPipeline[pidB]["long_running_updates"], "expected long_running_updates for pipeline B")
+
+	// Check long run description mentions hours
+	var longRunDesc string
+	for _, f := range report.Findings {
+		if f.Issue == "long_running_updates" && f.Resource.Name == pidB {
+			longRunDesc = f.Description
+		}
+	}
+	assert.NotEmpty(t, longRunDesc)
+	assert.Contains(t, longRunDesc, "hours")
+
+	cm.AssertExpectations(t)
+}
+
+func TestGetDLTAudit_CostManagerError(t *testing.T) {
+	ctx := context.Background()
+	ws := domain.Workspace{Name: "ws1"}
+	start := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 9, 8, 0, 0, 0, 0, time.UTC)
+
+	cm := new(mockCostManager)
+	errExpected := fmt.Errorf("error")
+	cm.On("GetResourcesCost", mock.Anything, domain.WorkspaceResources{WorkspaceName: ws.Name, Resources: []string{"dlt_pipeline", "dlt_update", "dlt_maintenance"}}, start, end).
+		Return(nil, errExpected)
+
+	_, err := GetDLTAudit(ctx, ws, start, end, cm)
+	assert.ErrorIs(t, err, errExpected)
+	cm.AssertExpectations(t)
+}


### PR DESCRIPTION
Add DLT pipeline audit endpoint, handler and service. 
The main logic is located in GetDLTPipeline function https://github.com/de-tools/data-atlas/blob/65b5d859c8fe8ab8c486f7d39865624cb8bb0bf2/pkg/services/account/workspace/audit.go#L12. 
Also added tests for this function https://github.com/de-tools/data-atlas/blob/65b5d859c8fe8ab8c486f7d39865624cb8bb0bf2/pkg/services/account/workspace/audit_test.go#L58-L58